### PR TITLE
Add stock value to HUD/overview in the top right.

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -173,7 +173,7 @@ export async function runCommand(ns, command, fileName, verbose = false, maxRetr
  **/
 export async function runCommand_Custom(ns, fnRun, command, fileName, verbose = false, maxRetries = 5, retryDelayMs = 50, ...args) {
     checkNsInstance(ns, '"runCommand_Custom"');
-    let script = `import { formatMoney, formatNumberShort, formatDuration, parseShortNumber, scanAllServers } fr` + `om "./helpers.js"\n` +
+    let script = `import { formatMoney, formatNumberShort, formatDuration, parseShortNumber, scanAllServers } fr` + `om "helpers.js"\n` +
         `export async function main(ns) { try { ` +
         (verbose ? `let output = ${command}; ns.tprint(output)` : command) +
         `; } catch(err) { ns.tprint(String(err)); throw(err); } }`;


### PR DESCRIPTION
Adds another param, to optionally disable. This change adds no ram cost. It also cleans up after itself on kill or --liquidate. Does not collide with other scripts using extra hud hooks.

The excessive use of parentElement in atExit() i found preferable to assigning id's and hacking document ram cost more than needed.

Also fixes path bug in helpers.js