### PR TITLE
Hacknet upgrade fix for Nodes if you have Formulas

### DIFF
--- a/hacknet-upgrade-manager.js
+++ b/hacknet-upgrade-manager.js
@@ -79,7 +79,7 @@ export function upgradeHacknet(ns, maxSpend, maxPayoffTimeSeconds = 3600 /* 3600
     for (var i = 0; i < ns.hacknet.numNodes(); i++) {
         let nodeStats = ns.hacknet.getNodeStats(i);
         if (formulas) { // When a hacknet server runs scripts, nodeStats.production lags behind what it should be for current ram usage. Get the "raw" rate
-            try { nodeStats.production = ns.formulas.hacknetServers.hashGainRate(nodeStats.level, 0, nodeStats.ram, nodeStats.cores, currentHacknetMult); }
+            try { ns.hacknet.hashCapacity() == 0 ? nodeStats.production = ns.formulas.hacknetNodes.moneyGainRate(nodeStats.level, nodeStats.ram, nodeStats.cores, currentHacknetMult) : nodeStats.production = ns.formulas.hacknetServers.hashGainRate(nodeStats.level, 0, nodeStats.ram, nodeStats.cores, currentHacknetMult); }
             catch { formulas = false; }
         }
         worstNodeProduction = Math.min(worstNodeProduction, nodeStats.production);

--- a/hacknet-upgrade-manager.js
+++ b/hacknet-upgrade-manager.js
@@ -79,7 +79,7 @@ export function upgradeHacknet(ns, maxSpend, maxPayoffTimeSeconds = 3600 /* 3600
     for (var i = 0; i < ns.hacknet.numNodes(); i++) {
         let nodeStats = ns.hacknet.getNodeStats(i);
         if (formulas && ns.hacknet.hashCapacity() > 0) { // When a hacknet server runs scripts, nodeStats.production lags behind what it should be for current ram usage. Get the "raw" rate
-            try { ns.hacknet.hashCapacity() == 0 ? nodeStats.production = ns.formulas.hacknetNodes.moneyGainRate(nodeStats.level, nodeStats.ram, nodeStats.cores, currentHacknetMult) : nodeStats.production = ns.formulas.hacknetServers.hashGainRate(nodeStats.level, 0, nodeStats.ram, nodeStats.cores, currentHacknetMult); }
+            try { nodeStats.production = ns.formulas.hacknetServers.hashGainRate(nodeStats.level, 0, nodeStats.ram, nodeStats.cores, currentHacknetMult); }
             catch { formulas = false; }
         }
         worstNodeProduction = Math.min(worstNodeProduction, nodeStats.production);

--- a/hacknet-upgrade-manager.js
+++ b/hacknet-upgrade-manager.js
@@ -78,7 +78,7 @@ export function upgradeHacknet(ns, maxSpend, maxPayoffTimeSeconds = 3600 /* 3600
     let worstNodeProduction = Number.MAX_VALUE; // Used to how productive a newly purchased node might be
     for (var i = 0; i < ns.hacknet.numNodes(); i++) {
         let nodeStats = ns.hacknet.getNodeStats(i);
-        if (formulas) { // When a hacknet server runs scripts, nodeStats.production lags behind what it should be for current ram usage. Get the "raw" rate
+        if (formulas && ns.hacknet.hashCapacity() > 0) { // When a hacknet server runs scripts, nodeStats.production lags behind what it should be for current ram usage. Get the "raw" rate
             try { ns.hacknet.hashCapacity() == 0 ? nodeStats.production = ns.formulas.hacknetNodes.moneyGainRate(nodeStats.level, nodeStats.ram, nodeStats.cores, currentHacknetMult) : nodeStats.production = ns.formulas.hacknetServers.hashGainRate(nodeStats.level, 0, nodeStats.ram, nodeStats.cores, currentHacknetMult); }
             catch { formulas = false; }
         }


### PR DESCRIPTION
nodeStats.production would pull hashrate from hacknet nodes, which would lead to incorrect values. Added check for hacknet nodes or servers and implemented production formula for nodes.