### PR TITLE
Fix support for downloading to subfolder

### DIFF
--- a/daemon.js
+++ b/daemon.js
@@ -1,10 +1,12 @@
 import {
     formatMoney, formatRam, formatDuration, formatDateTime, formatNumber,
-    scanAllServers, hashCode, disableLogs, log as logHelper,
+    scanAllServers, hashCode, disableLogs, log as logHelper, pathJoin,
     getNsDataThroughFile_Custom, runCommand_Custom, waitForProcessToComplete_Custom,
     tryGetBitNodeMultipliers_Custom, getActiveSourceFiles_Custom,
     getFnRunViaNsExec, getFnIsAliveViaNsPs
 } from './helpers.js'
+
+const subfolder = '';
 
 // the purpose of the daemon is: it's our global starting point.
 // it handles several aspects of the game, primarily hacking for money.
@@ -225,6 +227,7 @@ export async function main(ns) {
             shouldRun: () => 4 in dictSourceFiles && (ns.getServerMaxRam("home") >= 128 / (2 ** dictSourceFiles[4])) // Higher SF4 levels result in lower RAM requirements
         },
     ];
+    asynchronousHelpers.forEach(helper => helper.name = pathJoin(subfolder, helper.name));
     asynchronousHelpers.forEach(helper => helper.isLaunched = false);
     asynchronousHelpers.forEach(helper => helper.requiredServer = "home"); // All helpers should be launched at home since they use tempory scripts, and we only reserve ram on home
     // These scripts are spawned periodically (at some interval) to do their checks, with an optional condition that limits when they should be spawned
@@ -247,12 +250,14 @@ export async function main(ns) {
         { interval: 110000, name: "/Tasks/backdoor-all-servers.js", requiredServer: "home", shouldRun: () => 4 in dictSourceFiles },
         { interval: 111000, name: "host-manager.js", requiredServer: "home", shouldRun: () => !shouldReserveMoney() },
     ];
+    periodicScripts.forEach(tool => tool.name = pathJoin(subfolder, tool.name));
     hackTools = [
         { name: "/Remote/weak-target.js", shortName: "weak" },
         { name: "/Remote/grow-target.js", shortName: "grow" },
         { name: "/Remote/hack-target.js", shortName: "hack" },
         { name: "/Remote/manualhack-target.js", shortName: "manualhack" }
     ];
+    hackTools.forEach(tool => tool.name = pathJoin(subfolder, tool.name));
     // TODO: Revive these tools when needed.
     buildToolkit(ns); // build toolkit
     await getStaticServerData(ns, scanAllServers(ns)); // Gather information about servers that will never change

--- a/helpers.js
+++ b/helpers.js
@@ -81,6 +81,11 @@ export function hashCode(s) { return s.split("").reduce(function (a, b) { a = ((
 /** @param {NS} ns **/
 export function disableLogs(ns, listOfLogs) { ['disableLog'].concat(...listOfLogs).forEach(log => checkNsInstance(ns, '"disableLogs"').disableLog(log)); }
 
+/** Joins all arguments as components in a path, e.g. pathJoin("foo", "bar", "/baz") = "foo/bar/baz" **/
+export function pathJoin(...args) {
+    return args.join('/').replace(/\/\/+/g, '/');
+}
+
 // FUNCTIONS THAT PROVIDE ALTERNATIVE IMPLEMENTATIONS TO EXPENSIVE NS FUNCTIONS
 // VARIATIONS ON NS.RUN
 
@@ -175,7 +180,7 @@ export async function runCommand(ns, command, fileName, verbose = false, maxRetr
  **/
 export async function runCommand_Custom(ns, fnRun, command, fileName, verbose = false, maxRetries = 5, retryDelayMs = 50, ...args) {
     checkNsInstance(ns, '"runCommand_Custom"');
-    let script = `import { formatMoney, formatNumberShort, formatDuration, parseShortNumber, scanAllServers } fr` + `om "helpers.js"\n` +
+    let script = `import { formatMoney, formatNumberShort, formatDuration, parseShortNumber, scanAllServers } fr` + `om 'helpers.js'\n` +
         `export async function main(ns) { try { ` +
         (verbose ? `let output = ${command}; ns.tprint(output)` : command) +
         `; } catch(err) { ns.tprint(String(err)); throw(err); } }`;


### PR DESCRIPTION
This is a proposed fix for https://github.com/alainbryden/bitburner-scripts/issues/23 . It modifies git-pull.js to rewrite files as they are downloaded, updating path references to include the optional subfolder. This includes references to 'helper.js', as well as all the tools created in daemon.js.

I've had to include a workaround for what I believe is a bug in bitburner - importing a path relative to '.' doesn't seem to work. So the rewrite step in git-pull.js changes that to an absolute path.