### PR TITLE
fix(work-for-faction): do not stop script when SF 4 < 4.3

### DIFF
--- a/work-for-factions.js
+++ b/work-for-factions.js
@@ -122,7 +122,7 @@ export async function main(ns) {
     if (!(4 in dictSourceFiles))
         return ns.tprint("ERROR: You cannot automate working for factions until you have unlocked singularity access (SF4).");
     else if (dictSourceFiles[4] < 3)
-        return ns.tprint(`WARNING: Singularity functions are much more expensive with lower levels of SF4 (you have SF4.${dictSourceFiles[4]}). ` +
+        ns.tprint(`WARNING: Singularity functions are much more expensive with lower levels of SF4 (you have SF4.${dictSourceFiles[4]}). ` +
             `You may encounter RAM issues with and have to wait until you have more RAM available to run this script successfully.`);
 
     let bitnodeMults = await tryGetBitNodeMultipliers(ns); // Find out the current bitnode multipliers (if available)


### PR DESCRIPTION
Right now, the `work-for-faction` script will stop early with an error message in case you don't own SF 4.3 yet (e.g. 4.2 or 4.1), even though enough RAM might be available.

This small PR removes the early return and lets it run instead.