### PR TITLE
Removed "Bladeburner" Faction from factions

### DIFF
--- a/work-for-factions.js
+++ b/work-for-factions.js
@@ -19,7 +19,7 @@ const factionSpecificConfigs = [
 ]
 const factions = ["Illuminati", "Daedalus", "The Covenant", "ECorp", "MegaCorp", "Bachman & Associates", "Blade Industries", "NWO", "Clarke Incorporated", "OmniTek Incorporated",
     "Four Sigma", "KuaiGong International", "Fulcrum Secret Technologies", "BitRunners", "The Black Hand", "NiteSec", "Aevum", "Chongqing", "Ishima", "New Tokyo", "Sector-12",
-    "Volhaven", "Speakers for the Dead", "The Dark Army", "The Syndicate", "Silhouette", "Tetrads", "Slum Snakes", "Netburners", "Tian Di Hui", "CyberSec", "Bladeburners"];
+    "Volhaven", "Speakers for the Dead", "The Dark Army", "The Syndicate", "Silhouette", "Tetrads", "Slum Snakes", "Netburners", "Tian Di Hui", "CyberSec"]; //TODO: Add Bladeburner Automation at BN7.1
 // These factions should ideally be completed in this order (TODO: Check for augmentation dependencies)
 const preferredEarlyFactionOrder = [
     "Slum Snakes", // Unlock Gangs


### PR DESCRIPTION
The Bladeburner faction only gets reputation from activities inside the Bladeburner Module, you cant work for this faction.

Automation for the Bladeburner faction is available at BN7:
https://github.com/danielyxie/bitburner/blob/dev/markdown/bitburner.bladeburner.md

Fixes #43 