### PR TITLE
Host reserve by time since augment

### DIFF
--- a/host-manager.js
+++ b/host-manager.js
@@ -140,7 +140,6 @@ function tryToBuyBestServerPossible(ns) {
     // Vary reservation by time since augment. 
     // Decay factor of 0.2 = Starts willing to spend 95% of our money, backing down to ~75% at 1 hour, ~60% at 2 hours, ~25% at 6 hours, and ~10% at 10 hours.
     // Decay factor of 0.3 = Starts willing to spend 95% of our money, backing down to ~66% at 1 hour, ~45% at 2 hours, ~23% at 4 hours, ~10% at 6 hours
-    // Decay factor of 0.35 = Starts willing to spend 95% of our money, backing down to ~61% at 1 hour, ~40% at 2 hours, ~26% at 3 hours, ~17% at 4 hours, ~11% at 5 hours
     // Decay factor of 0.5 = Starts willing to spend 95% of our money, then halving every hour (to ~48% at 1 hour, ~24% at 2 hours, ~12% at 3 hours, etc)
     let t = ns.getTimeSinceLastAug() / (60 * 60 * 1000); // Time since last aug, in hours.
     let decayFactor = 0.5

--- a/host-manager.js
+++ b/host-manager.js
@@ -15,6 +15,9 @@ let reservedMoneyPercent = 0.99; // Don't spend more than 1% of our money on tem
 let minRamExponent = 10;
 // The name to give all purchased servers. Also used to determine which servers were purchased
 const purchasedServerName = "daemon";
+// Use experimental reserve-by-time adjustment.
+let varyReservebyTime = false;
+
 // Frequency of update
 const interval = 10000;
 
@@ -30,6 +33,7 @@ const argsSchema = [
     ['reserve-percent', 0.9], // Set to reserve a percentage of home money
     ['utilization-trigger', 0.95], // the percentage utilization that will trigger an attempted purchase
     ['min-ram-exponent', 5], // the minimum amount of ram to purchase
+    ['reserve-by-time', false], // Experimental exponential decay by time in the run. Starts willing to spend lots of money, falls off over time.
 ];
 
 export function autocomplete(data, _) {
@@ -51,6 +55,7 @@ export async function main(ns) {
     reservedMoneyPercent = options['reserve-percent'];
     utilizationTarget = options['utilization-trigger'];
     minRamExponent = options['min-ram-exponent'];
+    varyReservebyTime = options['reserve-by-time'];
     if (!keepRunning)
         ns.print(`host-manager will run once. Run with argument "-c" to run continuously.`)
     do {
@@ -132,6 +137,15 @@ function tryToBuyBestServerPossible(ns) {
         spendableMoney = Math.max(0, spendableMoney - 250000000);
     }
     // Additional reservations
+    // Vary reservation by time since augment. 
+    // Decay factor of 0.2 = Starts willing to spend 95% of our money, backing down to ~75% at 1 hour, ~60% at 2 hours, ~25% at 6 hours, and ~10% at 10 hours.
+    // Decay factor of 0.3 = Starts willing to spend 95% of our money, backing down to ~66% at 1 hour, ~45% at 2 hours, ~23% at 4 hours, ~10% at 6 hours
+    // Decay factor of 0.35 = Starts willing to spend 95% of our money, backing down to ~61% at 1 hour, ~40% at 2 hours, ~26% at 3 hours, ~17% at 4 hours, ~11% at 5 hours
+    // Decay factor of 0.5 = Starts willing to spend 95% of our money, then halving every hour (to ~48% at 1 hour, ~24% at 2 hours, ~12% at 3 hours, etc)
+    let t = ns.getTimeSinceLastAug() / (60 * 60 * 1000); // Time since last aug, in hours.
+    let decayFactor = 0.3
+    if (varyReservebyTime) reservedMoneyPercent = 1 - 0.95 * Math.pow(1 - decayFactor, t);
+
     spendableMoney = Math.max(0, Math.min(spendableMoney * (1 - reservedMoneyPercent), spendableMoney - reservedMoneyAmount));
     if (spendableMoney == 0)
         return setStatus(prefix + 'all cash is currently reserved.');
@@ -158,10 +172,10 @@ function tryToBuyBestServerPossible(ns) {
         // Abort if our home server is more than 2x bettter (rough guage of how much we 'need' Daemon RAM at the current stage of the game?)
         // Unless we're looking at buying the maximum purchasable server size - in which case we can do no better
         if (maxRamPossibleToBuy < ns.getServerMaxRam("home") / 4)
-            return setStatus(prefix + 'the most RAM we can buy (' + formatRam(maxRamPossibleToBuy) + ') is way less than (<0.25*) home RAM ' + formatRam(ns.getServerMaxRam("home")));
+            return setStatus(prefix + 'the most RAM we can buy (' + formatRam(maxRamPossibleToBuy) + ') on our budget of ' + formatMoney(spendableMoney) + ' is way less than (<0.25*) home RAM ' + formatRam(ns.getServerMaxRam("home")));
         // Abort if purchasing this server wouldn't improve our total RAM by more than 10% (ensures we buy in meaningful increments)
         if (maxRamPossibleToBuy / totalMaxRam < 0.1)
-            return setStatus(prefix + 'the most RAM we can buy (' + formatRam(maxRamPossibleToBuy) + ') is less than 10% of total available RAM ' + formatRam(totalMaxRam) + ')');
+            return setStatus(prefix + 'the most RAM we can buy (' + formatRam(maxRamPossibleToBuy) + ') on our budget of ' + formatMoney(spendableMoney) + ' is less than 10% of total available RAM ' + formatRam(totalMaxRam) + ')');
     }
 
     let maxPurchasableServerRam = Math.pow(2, maxPurchasableServerRamExponent)
@@ -184,11 +198,11 @@ function tryToBuyBestServerPossible(ns) {
     // Abort if our worst previously-purchased server is better than the one we're looking to buy (ensures we buy in sane increments of capacity)
     if (worstServerName != null && maxRamPossibleToBuy < worstServerRam)
         return setStatus(prefix + 'the most RAM we can buy (' + formatRam(maxRamPossibleToBuy) +
-            ') is less than our worst purchased server ' + worstServerName + '\'s RAM ' + formatRam(worstServerRam));
+            ') on our budget of ' + formatMoney(spendableMoney) + ' is less than our worst purchased server ' + worstServerName + '\'s RAM ' + formatRam(worstServerRam));
     // Only buy new servers as good as or better than our best bought server (anything less is considered a regression in value)
     if (bestServerRam != null && maxRamPossibleToBuy < bestServerRam)
         return setStatus(prefix + 'the most RAM we can buy (' + formatRam(maxRamPossibleToBuy) +
-            ') is less than our previously purchased server ' + bestServerName + " RAM " + formatRam(bestServerRam));
+            ') on our budget of ' + formatMoney(spendableMoney) + ' is less than our previously purchased server ' + bestServerName + " RAM " + formatRam(bestServerRam));
 
     // if we're at capacity, check to see if we can do better better than the current worst purchased server. If so, delete it to make room.
     if (purchasedServers.length >= maxPurchasedServers) {

--- a/host-manager.js
+++ b/host-manager.js
@@ -143,7 +143,7 @@ function tryToBuyBestServerPossible(ns) {
     // Decay factor of 0.35 = Starts willing to spend 95% of our money, backing down to ~61% at 1 hour, ~40% at 2 hours, ~26% at 3 hours, ~17% at 4 hours, ~11% at 5 hours
     // Decay factor of 0.5 = Starts willing to spend 95% of our money, then halving every hour (to ~48% at 1 hour, ~24% at 2 hours, ~12% at 3 hours, etc)
     let t = ns.getTimeSinceLastAug() / (60 * 60 * 1000); // Time since last aug, in hours.
-    let decayFactor = 0.3
+    let decayFactor = 0.5
     if (varyReservebyTime) reservedMoneyPercent = 1 - 0.95 * Math.pow(1 - decayFactor, t);
 
     spendableMoney = Math.max(0, Math.min(spendableMoney * (1 - reservedMoneyPercent), spendableMoney - reservedMoneyAmount));


### PR DESCRIPTION
I'm not sure if anyone else would find this useful, but I've been using the host manager with an exponential decay on the amount it's willing to spend based on the time since last augment. It seems to suit my play style pretty well. 

It starts out willing to spend basically all of your money, and cuts the amount in half every hour (95% when you first augment, then down to ~50% after an hour, ~25% at 2 hours, ~12% at 3 hours, etc.). The idea is to buy servers while we're still experiencing exponential money growth, but cut back later when we probably want to start saving up for the next augment instead of buying shiny new servers.

In most bitnodes, I start this script with the command line options '-c --utilization-trigger 0.7 --reserve-by-time'

