### PR TITLE
Show number of people killed

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -69,6 +69,13 @@ export async function main(ns) {
                 values.push(formatNumberShort(karma, 3, 2));
             }
 
+            playerInfo = (await getNsDataThroughFile(ns, 'ns.getPlayer()', '/Temp/player-info.txt'));
+            const numPeopleKilled = playerInfo.numPeopleKilled;
+            if (numPeopleKilled > 0) {
+                headers.push("Ppl Killed");
+                values.push(formatNumberShort(numPeopleKilled, 6, 0));
+            }
+
             const sharePower = ns.getSharePower();
             if (sharePower > 1) {
                 headers.push("Share Pwr");

--- a/stats.js
+++ b/stats.js
@@ -2,6 +2,7 @@ import { formatNumberShort, formatMoney, getNsDataThroughFile, getActiveSourceFi
 
 const argsSchema = [
     ['hide-stocks', false],
+    ['show-peoplekilled', false],
 ];
 
 export function autocomplete(data, args) {
@@ -69,11 +70,13 @@ export async function main(ns) {
                 values.push(formatNumberShort(karma, 3, 2));
             }
 
-            playerInfo = (await getNsDataThroughFile(ns, 'ns.getPlayer()', '/Temp/player-info.txt'));
-            const numPeopleKilled = playerInfo.numPeopleKilled;
-            if (numPeopleKilled > 0) {
-                headers.push("Ppl Killed");
-                values.push(formatNumberShort(numPeopleKilled, 6, 0));
+            if(options['show-peoplekilled']) {
+                playerInfo = (await getNsDataThroughFile(ns, 'ns.getPlayer()', '/Temp/player-info.txt'));
+                const numPeopleKilled = playerInfo.numPeopleKilled;
+                if (numPeopleKilled > 0) {
+                    headers.push("Ppl Killed");
+                    values.push(formatNumberShort(numPeopleKilled, 6, 0));
+                }
             }
 
             const sharePower = ns.getSharePower();


### PR DESCRIPTION
Useful to know because some factions require this statistic to be high enough.
As far as I could tell this information isn't shown anywhere else in the game's interface.
This change doesn't increase RAM usage according to the script editor.