### PR TITLE
Fix calculation for worthiness of studying hacking

### DIFF
--- a/work-for-factions.js
+++ b/work-for-factions.js
@@ -423,7 +423,7 @@ async function earnFactionInvite(ns, factionName) {
         const em = requirement / options['training-stat-per-multi-threshold'];
         if (options['no-studying'])
             return ns.print(`--no-studying is set, nothing we can do to improve hack level.`);
-        else if (Math.sqrt(player.hacking_exp * player.hacking_exp_mult) < em)
+        else if (Math.sqrt(player.hacking_mult * player.hacking_exp_mult) < em)
             return ns.print(`Hacking mult ${formatNumberShort(player.hacking_mult)} and exp_mult ${formatNumberShort(player.hacking_exp_mult)} ` +
                 `are probably too low to increase hack from ${player.hacking} to ${requirement} in a reasonable amount of time.`);
         let studying = false;


### PR DESCRIPTION
Currently, the script will almost always choose to study hacking because it's using hacking_exp instead of hacking_mult in the calculation. I believe this PR restores the intended behavior.