### PR TITLE
Fix access to deleting.txt flag when in subfolder.

### DIFF
--- a/daemon.js
+++ b/daemon.js
@@ -1640,7 +1640,7 @@ function removeServerByName(ns, deletedHostName) {
 let getServerByName = hostname => serverListByFreeRam.find(s => s.name == hostname);
 
 // Indication that a server has been flagged for deletion (by the host manager). Doesn't count for home of course, as this is where the flag file is stored for copying.
-let isFlaggedForDeletion = (hostName) => hostName != "home" && doesFileExist("/Flags/deleting.txt", hostName);
+let isFlaggedForDeletion = (hostName) => hostName != "home" && doesFileExist(getFilePath("/Flags/deleting.txt"), hostName);
 
 // Helper to construct our server lists from a list of all host names
 function buildServerList(ns, verbose = false) {

--- a/remove-worst-server.js
+++ b/remove-worst-server.js
@@ -1,4 +1,4 @@
-import { getNsDataThroughFile, runCommand, formatRam } from './helpers.js'
+import { getFilePath, getNsDataThroughFile, runCommand, formatRam } from './helpers.js'
 
 /** @param {NS} ns
  * Remove the worst owned server respective of RAM */
@@ -16,7 +16,7 @@ export async function main(ns) {
         return ns.tprint(`Nothing to delete - all ${purchasedServers.length} servers have the maximum RAM (2^20 or ${formatRam(2 ** 20)})`);
 
     // Flag the server for deletion with a file - daemon should check for this and stop scheduling against it.
-    await runCommand(ns, `await ns.scp("/Flags/deleting.txt", ns.args[0])`, '/Temp/flag-server-for-deletion.js', [minServer.name]);
+    await runCommand(ns, `await ns.scp("${getFilePath('/Flags/deleting.txt')}", ns.args[0])`, '/Temp/flag-server-for-deletion.js', [minServer.name]);
     const success = await getNsDataThroughFile(ns, `ns.deleteServer(ns.args[0])`, '/Temp/deleteServer.txt', [minServer.name]);
     if (success)
         ns.tprint(`Deleted ${minServer.name} which had ${formatRam(minServer.ram)} of RAM (${purchasedServers.length - 1} servers remaining).`);


### PR DESCRIPTION
If the repo is placed in a subfolder using `git-pull.js`, access to `/Flags/deleting.txt` does not respect the full path.

This means that the attempt to copy the flag over will fail because it's actually in `/subfolder/Flags/deleting.txt`, so nothing exists at `/Flags/deleting.txt`. This requires the lookup path to search in the subfolder as well.