### PR TITLE
fix an issue if reserve.txt becomes really big

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -71,7 +71,7 @@ export async function main(ns) {
             addHud("Scr Exp", formatNumberShort(ns.getScriptExpGain(), 3, 2) + '/sec', "Total 'instantenous' hack experience per second being earned across all scripts running on all servers.");
 
             // Show reserved money
-            const reserve = ns.read("reserve.txt") || 0;
+            const reserve = Number(ns.read("reserve.txt") || 0);
             if (reserve > 0) // Bitburner bug: Trace amounts of share power sometimes left over after we stop sharing
                 addHud("Reserve", formatNumberShort(reserve, 3, 2), "Most scripts will leave this much money unspent. Remove with `run reserve.js 0`");
 


### PR DESCRIPTION
credits go to cwnintendo...

So, think I found a bug in Stats/Helper, specifically `num.toExponential` not existing.
In bn3.3, near the end and started just pumping up the advertisements, and I've got a revenue of $1.550e+54 / sec. Then the stats.js started throwing a bunch of errors, dug it back down to the helper.js.

Dug some more, and it looks like something put an exponential number into reserve.txt. stats.js reads it in as a string, and so in line ~75 when it calls formatNumberShort, it doesn't work because the string doesn't have a toExponential function.