### PR TITLE
Disable rushing Netburners if sourcefile 9 is inactive.

### DIFF
--- a/work-for-factions.js
+++ b/work-for-factions.js
@@ -272,6 +272,11 @@ async function mainLoop(ns) {
         ns.print(`Fulcrum faction server requires ${fulcrummHackReq} hack, so removing from our initial priority list for now.`);
     } // TODO: Otherwise, if we get Fulcrum, we have no need for a couple other company factions
 
+    if (!(9 in dictSourceFiles)) {
+        priorityFactions.splice(priorityFactions.findIndex(c => c == "Netburners"), 1);
+        ns.print(`Skipping netburners because upgraded hashnet servers are not active.`);
+    }
+
     // Strategy 1: Tackle a consolidated list of desired faction order, interleaving simple factions and megacorporations
     const factionWorkOrder = firstFactions.concat(priorityFactions.filter(f => // Remove factions from our initial "work order" if we've bought all desired augmentations.
         !firstFactions.includes(f) && !skipFactions.includes(f) && !softCompletedFactions.includes(f)));


### PR DESCRIPTION
Before I had SourceFile 9, it always felt like a waste to rush the hacknet upgrades from Netburners. Without the actual hashes, I think hacknet ends up being an absolutely tiny portion of total income (and actually routinely negative because of the upgrade manager hah). 

Figured other users who are earlier on might appreciate skipping Netburners as well.