### PR TITLE
Avoid using bladeburner actions for sleeves if bladeburner API is n available

### DIFF
--- a/bladeburner.js
+++ b/bladeburner.js
@@ -54,9 +54,9 @@ export async function main(ns) {
     // Ensure we have access to bladeburner
     ownedSourceFiles = await getActiveSourceFiles(ns);
     //if (!(6 in ownedSourceFiles) && player.bitNodeN != 7) // NOTE: Despite the SF6 description, it seems you don't need SF6
-    //    return log(ns, "ERROR: You have no yet unlocked bladeburner outside of BNs 6 & 7 (need SF6)", true, 'error');
+    //    return log(ns, "ERROR: You have not yet unlocked bladeburner outside of BNs 6 & 7 (need SF6)", true, 'error');
     if (!(7 in ownedSourceFiles))
-        return log(ns, "ERROR: You have no yet unlocked the bladeburner API (need SF7)", true, 'error');
+        return log(ns, "ERROR: You have not yet unlocked the bladeburner API (need SF7)", true, 'error');
     if (player.bitNodeN == 8)
         return log(ns, "ERROR: Bladeburner is completely disabled in Bitnode 8 :`(\nHappy stonking", true, 'error');
     // Ensure we've joined bladeburners before proceeding further

--- a/sleeve.js
+++ b/sleeve.js
@@ -108,8 +108,11 @@ async function mainLoop(ns) {
         if (await getNsDataThroughFile(ns, 'ns.hacknet.spendHashes("Improve Gym Training")', '/Temp/spend-hashes-on-gym.txt'))
             log(ns, `SUCCESS: Bought "Improve Gym Training" to speed up Sleeve training.`, false, 'success');
     if (playerInfo.inBladeburner) {
-        const bladeburnerCity = await getNsDataThroughFile(ns, `ns.bladeburner.getCity()`, '/Temp/bladeburner-getCity.txt');
-        bladeburnerCityChaos = await getNsDataThroughFile(ns, `ns.bladeburner.getCityChaos(ns.args[0])`, '/Temp/bladeburner-getCityChaos.txt', [bladeburnerCity]);
+        ownedSourceFiles = await getActiveSourceFiles(ns);
+        if (7 in ownedSourceFiles) {
+            const bladeburnerCity = await getNsDataThroughFile(ns, `ns.bladeburner.getCity()`, '/Temp/bladeburner-getCity.txt');
+            bladeburnerCityChaos = await getNsDataThroughFile(ns, `ns.bladeburner.getCityChaos(ns.args[0])`, '/Temp/bladeburner-getCityChaos.txt', [bladeburnerCity]);
+        }
     }
 
     // Update all sleeve stats and loop over all sleeves to do some individual checks and task assignments
@@ -190,7 +193,7 @@ async function pickSleeveTask(ns, playerInfo, i, sleeve, canTrain) {
         /*   */ `helping earn rep with company ${playerInfo.companyName}.`];
     }
     // If the player is in bladeburner, and has already unlocked gangs with Karma, generate contracts and operations
-    if (playerInfo.inBladeburner && playerInGang) {
+    if (playerInfo.inBladeburner && playerInGang && (bladeburnerCityChaos !== undefined)) {
         const action = bladeburnerCityChaos > 10 ? "Diplomacy" : "Infiltrate synthoids"
         const contractName = "";
         return [`Bladeburner`, `ns.sleeve.setToBladeburnerAction(ns.args[0], ns.args[1], ns.args[2])`, [i, action, contractName],


### PR DESCRIPTION
When checking sleeve actions, the scripts determine whether the player is a bladeburner, but they do not check whether the bladeburner API is available. This leads to errors as soon as the player when the following conditions are met:
- The player has sleeves
- The player is a bladeburner
- The player is in a gang