### PR TITLE
Casino edge case

### DIFF
--- a/autopilot.js
+++ b/autopilot.js
@@ -423,9 +423,10 @@ async function maybeDoCasino(ns, player) {
 	//Or if BN8, as that also gives us plenty of starter cash to casino immediately
 	if (player.playtimeSinceLastAug < 60000 && !installedAugmentations.includes(`CashRoot Starter Kit`) && !player.bitNodeN == 8)
 		return;
-	// If we're making more than ~5b / minute, no need to run casino.
+	//If we're making more than ~5b / minute, no need to run casino.
 	//Unless BN8, if BN8 we always need casino cash bootstrap
-	if (player.money / player.playtimeSinceLastAug > 5e9 / 60000 && !player.bitNodeN == 8) 
+	//Since it's possible that the CashRoot Startker Kit could give a false income velocity, account for that.
+	if ((player.money - 1e6) / player.playtimeSinceLastAug > 5e9 / 60000 && !player.bitNodeN == 8) 
 		return ranCasino = true;
 	if (player.money > 10E9) // If we already have 10b, assume we ran and lost track, or just don't need the money
 		return ranCasino = true;


### PR DESCRIPTION
There is an edge case in the velocity check where the initial million from CashRoot can cause the script to think we are making more than 5b / minute in the very early moments of a new ascension. This should fix that by negating the cash.  I'm fairly certain this is better than adding a whole additional if clause, but I'm not sure if this is too "hacky" a solution, as we always negate a million, but I don't think it matters.