### PR TITLE
forcing to work for bestwork in faction

### DIFF
--- a/work-for-factions.js
+++ b/work-for-factions.js
@@ -908,6 +908,7 @@ async function detectBestFactionWork(ns, factionName) {
         mainLoopStart = 0; // Force break out of whatever work loop we're in to update info (maybe we formed a gang with the faction we were working for?)
         throw Error(`The faction "${factionName}" does not support any of the known work types. Cannot work for this faction!`);
     }
+    startWorkForFaction(ns, factionName, bestWork, shouldFocus); //force to work for best work found
     return bestWork;
 }
 


### PR DESCRIPTION
Is my first fork in a public repo so I hope it will be ok I fixed a bug where even if the function detectBestFactionWork was finding the best work in the targetted faction, there was no code to actually do the best work, but it was keeping doing the last one he checked. Now it checks, if needed throws errors, as before, and now, before returning bestWork, it also starts it.