### PR TITLE
Update git-pull.js

### DIFF
--- a/git-pull.js
+++ b/git-pull.js
@@ -41,7 +41,7 @@ export async function main(ns) {
     ns.tprint(`INFO: Pull complete. If you have any questions or issues, head over to the Bitburner #alains-scripts Discord channel: ` +
         `https://discord.com/channels/415207508303544321/935667531111342200`);
     // Remove any temp files / scripts from the prior version
-    ns.run(`${options.subfolder}/cleanup.js`);
+    ns.run(`${options.subfolder}cleanup.js`);
 }
 
 /** Joins all arguments as components in a path, e.g. pathJoin("foo", "bar", "/baz") = "foo/bar/baz" **/


### PR DESCRIPTION
Removed \ on line 44, for Release 2.3.0.
Because it wouldn't call the script correctly

No idea why it is marking a change in line 93, because I didn't change anything.