### PR TITLE
Fix TIX API access error

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -451,6 +451,10 @@ let cachedStockSymbols = null; // Cache of stock symbols since these never chang
  * Caches symbols the first time they are successfully requested, since symbols never change.
  * @param {NS} ns */
 export async function getStockSymbols(ns) {
+    const hasTixApiAccess = await getNsDataThroughFile(ns, 'ns.stock.hasTIXAPIAccess()');
+    if (!hasTixApiAccess) {
+        return null;
+    }
     cachedStockSymbols ??= await getNsDataThroughFile(ns,
         `(() => { try { return ns.stock.getSymbols(); } catch { return null; } })()`,
         '/Temp/stock-symbols.txt');


### PR DESCRIPTION
Resolves #311 
Apparently the API around `ns.stock.getSymbols()` changed from throwing an error to actually returning the symbols, even though TIX API access hasn't been bought yet.
To resolve this, I've added a check to the `getStockSymbols(ns)` method, which actively returns null when API access is unavailable, since this method is used internally to check on whether to work with stocks or not.

After changing this method, my ascend and autopilot worked as expected.