### PR TITLE
Implementation of #321 non-destructive communication between scripts

### DIFF
--- a/analyze-hack.js
+++ b/analyze-hack.js
@@ -1,4 +1,4 @@
-import { getConfiguration, disableLogs, formatMoney, scanAllServers } from './helpers.js'
+import { getConfiguration, disableLogs, formatMoney, scanAllServers, portRead, portWrite } from './helpers.js'
 
 const argsSchema = [
     ['all', false], // Set to true to report on all servers, not just the ones within our hack level
@@ -17,6 +17,34 @@ export function autocomplete(data, args) {
 export async function main(ns) {
     const options = getConfiguration(ns, argsSchema);
     if (!options) return; // Invalid options, or ran in --help mode.
+    let port = ns.getPortHandle(65000);
+    let tempdata = `{
+        "Analyze-hack": {
+          "all": {
+            "data": "${options['all']}",
+            "dataType": "Boolean"
+          },
+          "silent": {
+            "data": "${options['silent']}",
+            "dataType": "Boolean"
+          },
+          "at-hack-level": {
+            "data": "${options['at-hack-level']}",
+            "dataType": "Number"
+          },
+          "hack-percent": {
+            "data": "${options['hack-percent']}",
+            "dataType": "Number"
+          },
+          "include-hacknet-ram": {
+            "data": "${options['include-hacknet-ram']}",
+            "dataType": "Boolean"
+          }
+        }
+      }`
+    await portWrite(ns,port,tempdata)
+    ns.print(port.peek());
+    
     disableLogs(ns, ["scan", "sleep"]);
 
     let serverNames = scanAllServers(ns);

--- a/ascend.js
+++ b/ascend.js
@@ -1,6 +1,6 @@
 import {
     log, getConfiguration, getFilePath, runCommand, waitForProcessToComplete, getNsDataThroughFile,
-    getActiveSourceFiles, getStockSymbols
+    getActiveSourceFiles, getStockSymbols, portRead, portWrite
 } from './helpers.js'
 
 const argsSchema = [
@@ -30,6 +30,53 @@ export function autocomplete(data, args) {
 export async function main(ns) {
     const options = getConfiguration(ns, argsSchema);
     if (!options) return; // Invalid options, or ran in --help mode.
+    let port = ns.getPortHandle(65000);
+    let tempdata = `{
+        "Ascend": {
+          "install-augmentations": {
+            "data": "${options['install-augmentations']}",
+            "dataType": "Boolean"
+          },
+          "reset": {
+            "data": "${options['reset']}",
+            "dataType": "Boolean"
+          },
+          "allow-soft-reset": {
+            "data": "${options['allow-soft-reset']}",
+            "dataType": "Boolean"
+          },
+          "skip-staneks-gift": {
+            "data": "${options['skip-staneks-gift']}",
+            "dataType": "Boolean"
+          },
+          "bypass-stanek-warning": {
+            "data": "${options['bypass-stanek-warning']}",
+            "dataType": "Boolean"
+          },
+          "on-reset-script": {
+            "data": "${options['on-reset-script']}",
+            "dataType": "Object"
+          },
+          "ticks-to-wait-for-additional-purchases": {
+            "data": "${options['ticks-to-wait-for-additional-purchases']}",
+            "dataType": "Number"
+          },
+          "max-wait-time": {
+            "data": "${options['max-wait-time']}",
+            "dataType": "Number"
+          },
+          "prioritize-home-ram": {
+            "data": "${options['prioritize-home-ram']}",
+            "dataType": "Boolean"
+          },
+          "prioritize-augmentations": {
+            "data": "${options['prioritize-augmentations']}",
+            "dataType": "Boolean"
+          }
+        }
+      }`
+    await portWrite(ns,port,tempdata)
+    ns.print(port.peek());
     let dictSourceFiles = await getActiveSourceFiles(ns); // Find out what source files the user has unlocked
     if (!(4 in dictSourceFiles))
         return log(ns, "ERROR: You cannot automate installing augmentations until you have unlocked singularity access (SF4).", true, 'error');

--- a/bladeburner.js
+++ b/bladeburner.js
@@ -1,4 +1,4 @@
-import { log, disableLogs, getConfiguration, instanceCount, getNsDataThroughFile, getFilePath, getActiveSourceFiles, formatNumberShort, formatDuration } from './helpers.js'
+import { log, disableLogs, getConfiguration, instanceCount, getNsDataThroughFile, getFilePath, getActiveSourceFiles, formatNumberShort, formatDuration, portRead, portWrite } from './helpers.js'
 
 const cityNames = ["Sector-12", "Aevum", "Volhaven", "Chongqing", "New Tokyo", "Ishima"];
 const antiChaosOperation = "Stealth Retirement Operation"; // Note: Faster and more effective than Diplomacy at reducing city chaos
@@ -52,6 +52,70 @@ export async function main(ns) {
     const runOptions = getConfiguration(ns, argsSchema);
     if (!runOptions || await instanceCount(ns) > 1) return; // Prevent multiple instances of this script from being started, even with different args.
     options = runOptions; // We don't set the global "options" until we're sure this is the only running instance
+    let port = ns.getPortHandle(65000);
+    let tempdata = `{
+        "Bladeburner": {
+          "success-threshold": {
+            "data": "${options['success-threshold']}",
+            "dataType": "Number"
+          },
+          "chaos-recovery-threshold": {
+            "data": "${options['chaos-recovery-threshold']}",
+            "dataType": "Number"
+          },
+          "max-chaos": {
+            "data": "${options['max-chaos']}",
+            "dataType": "Number"
+          },
+          "toast-upgrades": {
+            "data": "${options['toast-upgrades']}",
+            "dataType": "Boolean"
+          },
+          "toast-operations": {
+            "data": "${options['toast-operations']}",
+            "dataType": "Boolean"
+          },
+          "toast-relocations": {
+            "data": "${options['toast-relocations']}",
+            "dataType": "Boolean"
+          },
+          "low-stamina-pct": {
+            "data": "${options['low-stamina-pct']}",
+            "dataType": "Number"
+          },
+          "high-stamina-pct": {
+            "data": "${options['high-stamina-pct']}",
+            "dataType": "Number"
+          },
+          "training-limit": {
+            "data": "${options['training-limit']}",
+            "dataType": "Number"
+          },
+          "update-interval": {
+            "data": "${options['update-interval']}",
+            "dataType": "Number"
+          },
+          "ignore-busy-status": {
+            "data": "${options['ignore-busy-status']}",
+            "dataType": "Boolean"
+          },
+          "allow-raiding-highest-pop-city": {
+            "data": "${options['allow-raiding-highest-pop-city']}",
+            "dataType": "Boolean"
+          },
+          "reserved-action-count": {
+            "data": "${options['reserved-action-count']}",
+            "dataType": "Number"
+          },
+          "disable-spending-hashes": {
+            "data": "${options['disable-spending-hashes']}",
+            "dataType": "Boolean"
+          }
+        }
+      }
+      `
+    await portWrite(ns,port,tempdata)
+    ns.print(port.peek());
     disableLogs(ns, ['sleep'])
     player = await getNsDataThroughFile(ns, 'ns.getPlayer()');
     resetInfo = await getNsDataThroughFile(ns, 'ns.getResetInfo()');

--- a/casino.js
+++ b/casino.js
@@ -1,4 +1,4 @@
-import { log, getConfiguration, getFilePath, waitForProcessToComplete, runCommand, getNsDataThroughFile, autoRetry } from './helpers.js'
+import { log, getConfiguration, getFilePath, waitForProcessToComplete, runCommand, getNsDataThroughFile, autoRetry, portRead, portWrite } from './helpers.js'
 
 const ran_flag = "/Temp/ran-casino.txt"
 let doc = eval("document");
@@ -34,6 +34,48 @@ function tailAndLog(ns, message) {
 export async function main(ns) {
     options = getConfiguration(ns, argsSchema);
     if (!options) return; // Invalid options, or ran in --help mode.
+   
+   // Below is the code to write the settings to the port, however, I have disabled the code since this script is meant to run fast and it would only slow it down
+    /* let port = ns.getPortHandle(65000);
+    let tempdata = `{
+        "Casino": {
+          "save-sleep-time": {
+            "data": "${options['save-sleep-time']}",
+            "dataType": "Number"
+          },
+          "click-sleep-time": {
+            "data": "${options['click-sleep-time']}",
+            "dataType": "Number"
+          },
+          "use-basic-strategy": {
+            "data": "${options['use-basic-strategy']}",
+            "dataType": "Boolean"
+          },
+          "enable-logging": {
+            "data": "${options['enable-logging']}",
+            "dataType": "Boolean"
+          },
+          "kill-all-scripts": {
+            "data": "${options['kill-all-scripts']}",
+            "dataType": "Boolean"
+          },
+          "no-deleting-remote-files": {
+            "data": "${options['no-deleting-remote-files']}",
+            "dataType": "Boolean"
+          },
+          "on-completion-script": {
+            "data": "${options['on-completion-script']}",
+            "dataType": "String"
+          },
+          "on-completion-script-args": {
+            "data": "${options['on-completion-script-args']}",
+            "dataType": "Array"
+          }
+        }
+      }
+      `
+    await portWrite(ns,port,tempdata)
+    ns.print(port.peek()); */
     _ns = ns;
     const saveSleepTime = options['save-sleep-time'];
     if (options['enable-logging'])

--- a/daemon.js
+++ b/daemon.js
@@ -214,9 +214,9 @@ export async function main(ns) {
     // In the future data might be stored here that scripts use during start up but for now we dont have any of that
     port.write("{}")
 
-    let tempdata ='{"Daemon":{"XP Mode":{"dataType": "boolean","data": "false"}}}';
-    await portWrite(ns,port,tempdata)
-    ns.print(port.peek());
+    //let tempdata ='{"Daemon":{"XP Mode":{"dataType": "boolean","data": "false"}}}';
+    // Create thre data string of all the deamons options
+    
 
     daemonHost = "home"; // ns.getHostname(); // get the name of this node (realistically, will always be home)
     const runOptions = getConfiguration(ns, argsSchema);
@@ -287,6 +287,158 @@ export async function main(ns) {
     queueDelay = options['queue-delay'];
     maxBatches = options['max-batches'];
     homeReservedRam = options['reserved-ram']
+
+    let tempdata = `
+    {
+      "Daemon": {
+        "h": {
+          "data": "${options.h}",
+          "dataType": "boolean"
+        },
+        "hack-only": {
+          "data": "${options['hack-only']}",
+          "dataType": "boolean"
+        },
+        "s": {
+          "data": "${options.s}",
+          "dataType": "boolean"
+        },
+        "stock-manipulation": {
+          "data": "${options['stock-manipulation']}",
+          "dataType": "boolean"
+        },
+        "disable-stock-manipulation": {
+          "data": "${options['disable-stock-manipulation']}",
+          "dataType": "boolean"
+        },
+        "stock-manipulation-focus": {
+          "data": "${options['stock-manipulation-focus']}",
+          "dataType": "boolean"
+        },
+        "v": {
+          "data": "${options.v}",
+          "dataType": "boolean"
+        },
+        "verbose": {
+          "data": "${options['verbose']}",
+          "dataType": "boolean"
+        },
+        "o": {
+          "data": "${options.o}",
+          "dataType": "boolean"
+        },
+        "run-once": {
+          "data": "${options['run-once']}",
+          "dataType": "boolean"
+        },
+        "x": {
+          "data": "${options.x}",
+          "dataType": "boolean"
+        },
+        "xp-only": {
+          "data": "${options['xp-only']}",
+          "dataType": "boolean"
+        },
+        "n": {
+          "data": "${options.n}",
+          "dataType": "boolean"
+        },
+        "use-hacknet-nodes": {
+          "data": "${options['use-hacknet-nodes']}",
+          "dataType": "boolean"
+        },
+        "use-hacknet-servers": {
+          "data": "${options['use-hacknet-servers']}",
+          "dataType": "boolean"
+        },
+        "spend-hashes-for-money-when-under": {
+          "data": "${options['spend-hashes-for-money-when-under']}",
+          "dataType": "float"
+        },
+        "disable-spend-hashes": {
+          "data": "${options['disable-spend-hashes']}",
+          "dataType": "boolean"
+        },
+        "silent-misfires": {
+          "data": "${options['silent-misfires']}",
+          "dataType": "boolean"
+        },
+        "initial-max-targets": {
+          "data": "${options['initial-max-targets']}",
+          "dataType": "int"
+        },
+        "max-steal-percentage": {
+          "data": "${options['max-steal-percentage']}",
+          "dataType": "float"
+        },
+        "cycle-timing-delay": {
+          "data": "${options['cycle-timing-delay']}",
+          "dataType": "int"
+        },
+        "queue-delay": {
+          "data": "${options['queue-delay']}",
+          "dataType": "int"
+        },
+        "max-batches": {
+          "data": "${options['max-batches']}",
+          "dataType": "int"
+        },
+        "i": {
+          "data": "${options['i']}",
+          "dataType": "boolean"
+        },
+        "reserved-ram": {
+          "data": "${options['reserved-ram']}",
+          "dataType": "int"
+        },
+        "looping-mode": {
+          "data": "${options['looping-mode']}",
+          "dataType": "boolean"
+        },
+        "recovery-thread-padding": {
+          "data": "${options['recovery-thread-padding']}",
+          "dataType": "int"
+        },
+        "share": {
+          "data": "${options['share']}",
+          "dataType": "boolean"
+        },
+        "no-share": {
+          "data": "${options['no-share']}",
+          "dataType": "boolean"
+        },
+        "share-cooldown": {
+          "data": "${options['share-cooldown']}",
+          "dataType": "int"
+        },
+        "share-max-utilization": {
+          "data": "${options['share-max-utilization']}",
+          "dataType": "float"
+        },
+        "no-tail-windows": {
+          "data": "${options['no-tail-windows']}",
+          "dataType": "boolean"
+        },
+        "initial-study-time": {
+          "data": "${options['initial-study-time']}",
+          "dataType": "int"
+        },
+        "initial-hack-xp-time": {
+          "data": "${options['initial-hack-xp-time']}",
+          "dataType": "int"
+        },
+        "disable-script": {
+          "data": "${options['disable-script']}",
+          "dataType": "array"
+        },
+        "run-script": {
+          "data": "${options['run-script']}",
+          "dataType": "array"
+        }
+      }
+    }`    
+    await portWrite(ns,port,tempdata)
+    ns.print(port.peek());
 
     // These scripts are started once and expected to run forever (or terminate themselves when no longer needed)
     const openTailWindows = !options['no-tail-windows'];
@@ -579,7 +731,7 @@ async function doTargetingLoop(ns, port) {
         if (options.x || options['xp-only']){
             ns.print("The daemon was started in XP-only mode. Skipping port read.")
         } else{
-            let tempboolforxp = await portRead(ns, port, "Daemon", "XP Mode");
+            let tempboolforxp = await portRead(ns, port, "Daemon", "xp-only");
             //ns.print("tempboolforxp: " + tempboolforxp);
             xpOnly = Boolean(tempboolforxp);
         }

--- a/faction-manager.js
+++ b/faction-manager.js
@@ -1,6 +1,6 @@
 import {
     log, getConfiguration, instanceCount, formatNumberShort, formatMoney,
-    getNsDataThroughFile, getActiveSourceFiles, tryGetBitNodeMultipliers, getStocksValue
+    getNsDataThroughFile, getActiveSourceFiles, tryGetBitNodeMultipliers, getStocksValue, portRead, portWrite
 } from './helpers.js'
 
 // PLAYER CONFIGURATION CONSTANTS
@@ -94,6 +94,98 @@ export async function main(ns) {
     const runOptions = getConfiguration(ns, argsSchema);
     if (!runOptions || await instanceCount(ns) > 1) return; // Prevent multiple instances of this script from being started, even with different args.
     options = runOptions; // We don't set the global "options" until we're sure this is the only running instance
+    let port = ns.getPortHandle(65000);
+    let tempdata = `{
+        "Faction-manager": {
+          "all": {
+            "data": "${options['all'] || options.a}",
+            "dataType": "Boolean"
+          },
+          "hide-locked-factions": {
+            "data": "${options['hide-locked-factions']}",
+            "dataType": "Boolean"
+          },
+          "verbose": {
+            "data": "${options['verbose'] || options.v}",
+            "dataType": "Boolean"
+          },
+          "ignore-player-data": {
+            "data": "${options['ignore-player-data'] || options.i}",
+            "dataType": "Boolean"
+          },
+          "ignore-faction": {
+            "data": "${options['ignore-faction']}",
+            "dataType": "Array"
+          },
+          "after-faction": {
+            "data": "${options['after-faction']}",
+            "dataType": "Array"
+          },
+          "force-join": {
+            "data": "${options['force-join']}",
+            "dataType": "Array"
+          },
+          "priority-aug": {
+            "data": "${options['priority-aug']}",
+            "dataType": "Array"
+          },
+          "omit-aug": {
+            "data": "${options['omit-aug']}",
+            "dataType": "Array"
+          },
+          "aug-desired": {
+            "data": "${options['aug-desired']}",
+            "dataType": "Array"
+          },
+          "stat-desired": {
+            "data": "${options['stat-desired']}",
+            "dataType": "Array"
+          },
+          "neuroflux-disabled": {
+            "data": "${options['neuroflux-disabled']}",
+            "dataType": "Boolean"
+          },
+          "disable-donations": {
+            "data": "${options['disable-donations']}",
+            "dataType": "Boolean"
+          },
+          "purchase": {
+            "data": "${options['purchase']}",
+            "dataType": "Boolean"
+          },
+          "ignore-stocks": {
+            "data": "${options['ignore-stocks']}",
+            "dataType": "Boolean"
+          },
+          "ignore-stanek": {
+            "data": "${options['ignore-stanek']}",
+            "dataType": "Boolean"
+          },
+          "show-unavailable-aug-purchase-order": {
+            "data": "${options['show-unavailable-aug-purchase-order']}",
+            "dataType": "Boolean"
+          },
+          "show-all-purchase-lists": {
+            "data": "${options['show-all-purchase-lists']}",
+            "dataType": "Boolean"
+          },
+          "sort": {
+            "data": "${options['sort']}",
+            "dataType": "String"
+          },
+          "hide-stat": {
+            "data": "${options['hide-stat']}",
+            "dataType": "Array"
+          },
+          "unique": {
+            "data": "${options['unique'] || options.u}",
+            "dataType": "Boolean"
+          }
+        }
+      }
+      `
+    await portWrite(ns,port,tempdata)
+    ns.print(port.peek());
     _ns = ns;
 
     // Ensure all globals are reset before we proceed with the script, in case we've done things out of order

--- a/gangs.js
+++ b/gangs.js
@@ -1,6 +1,6 @@
 import {
     log, getConfiguration, instanceCount, getNsDataThroughFile, getActiveSourceFiles, runCommand, tryGetBitNodeMultipliers,
-    formatMoney, formatNumberShort, formatDuration
+    formatMoney, formatNumberShort, formatDuration, portRead, portWrite
 } from './helpers.js'
 
 // Global config
@@ -71,6 +71,58 @@ export async function main(ns) {
     const runOptions = getConfiguration(ns, argsSchema);
     if (!runOptions || await instanceCount(ns) > 1) return; // Prevent multiple instances of this script from being started, even with different args.
     options = runOptions; // We don't set the global "options" until we're sure this is the only running instance
+    let port = ns.getPortHandle(65000);
+    let tempdata = `{
+        "Gangs": {
+          "training-percentage": {
+            "data": "${options['training-percentage']}",
+            "dataType": "Number"
+          },
+          "no-training": {
+            "data": "${options['no-training']}",
+            "dataType": "Boolean"
+          },
+          "no-auto-ascending": {
+            "data": "${options['no-auto-ascending']}",
+            "dataType": "Boolean"
+          },
+          "ascend-multi-threshold": {
+            "data": "${options['ascend-multi-threshold']}",
+            "dataType": "Number"
+          },
+          "ascend-multi-threshold-spacing": {
+            "data": "${options['ascend-multi-threshold-spacing']}",
+            "dataType": "Number"
+          },
+          "min-training-ticks": {
+            "data": "${options['min-training-ticks']}",
+            "dataType": "Number"
+          },
+          "reserve": {
+            "data": "${options['reserve']}",
+            "dataType": "Number"
+          },
+          "augmentations-budget": {
+            "data": "${options['augmentations-budget']}",
+            "dataType": "Number"
+          },
+          "equipment-budget": {
+            "data": "${options['equipment-budget']}",
+            "dataType": "Number"
+          },
+          "money-focus": {
+            "data": "${options['money-focus']}",
+            "dataType": "Boolean"
+          },
+          "reputation-focus": {
+            "data": "${options['reputation-focus']}",
+            "dataType": "Boolean"
+          }
+        }
+      }
+      `
+    await portWrite(ns,port,tempdata)
+    ns.print(port.peek());
     ownedSourceFiles = await getActiveSourceFiles(ns);
     const sf2Level = ownedSourceFiles[2] || 0;
     if (sf2Level == 0)

--- a/hacknet-upgrade-manager.js
+++ b/hacknet-upgrade-manager.js
@@ -1,4 +1,4 @@
-import { getConfiguration, disableLogs, formatDuration, formatMoney, } from './helpers.js'
+import { getConfiguration, disableLogs, formatDuration, formatMoney, portRead, portWrite } from './helpers.js'
 
 let haveHacknetServers = true; // Cached flag after detecting whether we do (or don't) have hacknet servers
 const argsSchema = [
@@ -22,6 +22,42 @@ export function autocomplete(data, _) {
 export async function main(ns) {
     const options = getConfiguration(ns, argsSchema);
     if (!options) return; // Invalid options, or ran in --help mode.
+    let port = ns.getPortHandle(65000);
+    let tempdata = `{
+        "Hacknet-upgrade-manager": {
+          "max-payoff-time": {
+            "data": "${options['max-payoff-time']}",
+            "dataType": "String"
+          },
+          "time": {
+            "data": "${options['time']}",
+            "dataType": "String"
+          },
+          "continuous": {
+            "data": "${options['continuous'] || options.c}",
+            "dataType": "Boolean"
+          },
+          "interval": {
+            "data": "${options['interval']}",
+            "dataType": "Number"
+          },
+          "max-spend": {
+            "data": "${options['max-spend']}",
+            "dataType": "Number"
+          },
+          "toast": {
+            "data": "${options['toast']}",
+            "dataType": "Boolean"
+          },
+          "reserve": {
+            "data": "${options['reserve']}",
+            "dataType": "Number"
+          }
+        }
+      }
+      `
+    await portWrite(ns,port,tempdata)
+    ns.print(port.peek());
     const continuous = options.c || options.continuous;
     const interval = options.interval;
     let maxSpend = options["max-spend"];

--- a/helpers.js
+++ b/helpers.js
@@ -777,7 +777,30 @@ export async function portRead(ns, port, category, dataName) {
         ns.write("Temp/portLog.txt", log, "a");
         return null;
     }
+    // lets log the success
+    datetiem = Date(Date.now()).toString();
+    log = `[${uuid}][${datetiem}][${scriptName}]: successfully read ${dataName} from the port.\n`;
+    ns.write("Temp/portLog.txt", log, "a");
 
+
+    ns.print("deserializing data");
+    // assuming that the data we got was serialized properly we now need to deserialize it and return it to the calling script.
+    switch(data[category][dataName]["dataType"]){
+        case "string":
+            return data[category][dataName]["data"];
+        case "number":
+            return Number(data[category][dataName]["data"]);
+        case "boolean":
+            return Boolean(data[category][dataName]["data"]);
+        case "array":
+            return JSON.parse(data[category][dataName]["data"]);
+        case "object":
+            return JSON.parse(data[category][dataName]["data"]);
+        default:
+            return data[category][dataName]["data"];
+    }
+
+    
     // lets return the data you requested. All the data is going to be a string so have fun turning it into whatever its supposed to be.
     // TODO: return the data in the correct format. or tell the script what format it is supposed to be in.
     return data[category][dataName]["data"];

--- a/helpers.js
+++ b/helpers.js
@@ -716,6 +716,10 @@ export async function portWrite(ns, port, newData, retry = true) {
             return false;
         }
     }
+    // logging a successful write to the port.
+    datetiem = Date(Date.now()).toString();
+    log = `[${uuid}][${datetiem}][${scriptName}]: successfully wrote to the port.\n`;
+    ns.write("Temp/portLog.txt", log, "a");
     return true;
 
 }
@@ -757,7 +761,7 @@ export async function portRead(ns, port, category, dataName) {
     ns.write("Temp/portLog.txt", log, "a");
     // lets start by getting the data from the port no need to read it if its empty.
     let data = port.peek();
-    //ns.print(data)
+    ns.print(data)
     // Now lets parse the data so we can grab information from it.
     data = JSON.parse(data);
 
@@ -767,6 +771,10 @@ export async function portRead(ns, port, category, dataName) {
         let testshit = data[category][dataName]["data"];
     } catch(error){
         ns.print("Failed to read data from port. Returning null.");
+        // lets log the error
+        datetiem = Date(Date.now()).toString();
+        log = `[${uuid}][${datetiem}][${scriptName}]: failed to read ${dataName} from the port: ${error}\n`;
+        ns.write("Temp/portLog.txt", log, "a");
         return null;
     }
 

--- a/helpers.js
+++ b/helpers.js
@@ -604,6 +604,7 @@ export function unEscapeArrayArgs(args) {
 */
 
 /** Standardized write method for ports. This will add or modify data within the port without lossing the data within it.
+ * TODO: Fix this code its complete shit and there has to be a better way of doing this. I should probably make a safe version of this to prevent format disruption
  * @param {NS} ns
  * @param {NetscriptPort} port - the script needs to define the port object as its probably not a good idea to have the port defined everytime this function is called.
  * @param {string} data - This needs to be a sting that follows the standard format for the port. make sure that the data you intend on writting has been stringified to prevent errors.
@@ -627,13 +628,8 @@ export async function portWrite(ns, port, data, retry = true) {
             if(category in oldData){
                 // lets loop through the data in the category and add it to the old data.
                 for (const dataName in data[category]){
-                    if(dataName in oldData[category]){
-                        // lets add the data to the old data.
                         oldData[category][dataName]["data"] = data[category][dataName]["data"];
-                    }else{
-                        // lets add the data to the old data.
                         oldData[category][dataName]["dataType"] = data[category][dataName]["dataType"];
-                    }
                 }
             }else{
                 // lets add the data to the old data.

--- a/host-manager.js
+++ b/host-manager.js
@@ -1,4 +1,4 @@
-import { log, getConfiguration, instanceCount, getNsDataThroughFile, scanAllServers, formatMoney, formatRam } from './helpers.js'
+import { log, getConfiguration, instanceCount, getNsDataThroughFile, scanAllServers, formatMoney, formatRam, portRead, portWrite } from './helpers.js'
 
 // The purpose of the host manager is to buy the best servers it can
 // until it thinks RAM is underutilized enough that you don't need to anymore.
@@ -39,6 +39,54 @@ export async function main(ns) {
     const runOptions = getConfiguration(ns, argsSchema);
     if (!runOptions || await instanceCount(ns) > 1) return; // Prevent multiple instances of this script from being started, even with different args.
     options = runOptions; // We don't set the global "options" until we're sure this is the only running instance
+    let port = ns.getPortHandle(65000);
+    let tempdata = `{
+        "Host-manager": {
+            "continuous": {
+            "data": "${options.c || options['run-continuously']}",
+            "dataType": "Boolean"
+            },
+            "interval": {
+            "data": "${options['interval']}",
+            "dataType": "Number"
+            },
+            "min-ram-exponent": {
+            "data": "${options['min-ram-exponent']}",
+            "dataType": "Number"
+            },
+            "utilization-trigger": {
+            "data": "${options['utilization-trigger']}",
+            "dataType": "Number"
+            },
+            "absolute-reserve": {
+            "data": "${options['absolute-reserve']}",
+            "dataType": "Number"
+            },
+            "reserve-percent": {
+            "data": "${options['reserve-percent']}",
+            "dataType": "Number"
+            },
+            "reserve-by-time": {
+            "data": "${options['reserve-by-time']}",
+            "dataType": "Boolean"
+            },
+            "allow-worse-purchases": {
+            "data": "${options['allow-worse-purchases']}",
+            "dataType": "Boolean"
+            },
+            "compare-to-home-threshold": {
+            "data": "${options['compare-to-home-threshold']}",
+            "dataType": "Number"
+            },
+            "compare-to-network-ram-threshold": {
+            "data": "${options['compare-to-network-ram-threshold']}",
+            "dataType": "Number"
+            }
+        }
+      }
+      `
+    await portWrite(ns,port,tempdata)
+    ns.print(port.peek());
     ns.disableLog('ALL')
 
     // Get the maximum number of purchased servers in this bitnode

--- a/sleeve.js
+++ b/sleeve.js
@@ -1,4 +1,4 @@
-import { log, getConfiguration, instanceCount, disableLogs, getActiveSourceFiles, getNsDataThroughFile, runCommand, formatMoney, formatDuration } from './helpers.js'
+import { log, getConfiguration, instanceCount, disableLogs, getActiveSourceFiles, getNsDataThroughFile, runCommand, formatMoney, formatDuration, portRead, portWrite } from './helpers.js'
 
 const argsSchema = [
     ['min-shock-recovery', 97], // Minimum shock recovery before attempting to train or do crime (Set to 100 to disable, 0 to recover fully)
@@ -51,6 +51,98 @@ export async function main(ns) {
     const runOptions = getConfiguration(ns, argsSchema);
     if (!runOptions || await instanceCount(ns) > 1) return; // Prevent multiple instances of this script from being started, even with different args.
     options = runOptions; // We don't set the global "options" until we're sure this is the only running instance
+    let port = ns.getPortHandle(65000);
+    let tempdata = `{
+        "Sleeve": {
+            "min-shock-recovery": {
+            "data": "${options['min-shock-recovery']}",
+            "dataType": "Number"
+            },
+            "shock-recovery": {
+            "data": "${options['shock-recovery']}",
+            "dataType": "Number"
+            },
+            "crime": {
+            "data": "${options['crime']}",
+            "dataType": "String"
+            },
+            "homicide-chance-threshold": {
+            "data": "${options['homicide-chance-threshold']}",
+            "dataType": "Number"
+            },
+            "disable-gang-homicide-priority": {
+            "data": "${options['disable-gang-homicide-priority']}",
+            "dataType": "Boolean"
+            },
+            "aug-budget": {
+            "data": "${options['aug-budget']}",
+            "dataType": "Number"
+            },
+            "buy-cooldown": {
+            "data": "${options['buy-cooldown']}",
+            "dataType": "Number"
+            },
+            "min-aug-batch": {
+            "data": "${options['min-aug-batch']}",
+            "dataType": "Number"
+            },
+            "reserve": {
+            "data": "${options['reserve']}",
+            "dataType": "Number"
+            },
+            "disable-follow-player": {
+            "data": "${options['disable-follow-player']}",
+            "dataType": "Boolean"
+            },
+            "disable-training": {
+            "data": "${options['disable-training']}",
+            "dataType": "Boolean"
+            },
+            "train-to-strength": {
+            "data": "${options['train-to-strength']}",
+            "dataType": "Number"
+            },
+            "train-to-defense": {
+            "data": "${options['train-to-defense']}",
+            "dataType": "Number"
+            },
+            "train-to-dexterity": {
+            "data": "${options['train-to-dexterity']}",
+            "dataType": "Number"
+            },
+            "train-to-agility": {
+            "data": "${options['train-to-agility']}",
+            "dataType": "Number"
+            },
+            "training-reserve": {
+            "data": "${options['training-reserve']}",
+            "dataType": "Number"
+            },
+            "training-cap-seconds": {
+            "data": "${options['training-cap-seconds']}",
+            "dataType": "Number"
+            },
+            "disable-spending-hashes-for-gym-upgrades": {
+            "data": "${options['disable-spending-hashes-for-gym-upgrades']}",
+            "dataType": "Boolean"
+            },
+            "enable-bladeburner-team-building": {
+            "data": "${options['enable-bladeburner-team-building']}",
+            "dataType": "Boolean"
+            },
+            "disable-bladeburner": {
+            "data": "${options['disable-bladeburner']}",
+            "dataType": "Boolean"
+            },
+            "failed-bladeburner-contract-cooldown": {
+            "data": "${options['failed-bladeburner-contract-cooldown']}",
+            "dataType": "Number"
+            }
+        }
+      }
+      `
+    await portWrite(ns,port,tempdata)
+    ns.print(port.peek());
     disableLogs(ns, ['getServerMoneyAvailable']);
     // Ensure the global state is reset (e.g. after entering a new bitnode)
     task = [], lastStatusUpdateTime = [], lastPurchaseTime = [], lastPurchaseStatusUpdate = [], availableAugs = [],

--- a/spend-hacknet-hashes.js
+++ b/spend-hacknet-hashes.js
@@ -1,4 +1,4 @@
-import { log, getConfiguration, disableLogs, formatMoney, formatDuration, formatNumberShort } from './helpers.js'
+import { log, getConfiguration, disableLogs, formatMoney, formatDuration, formatNumberShort, portRead, portWrite } from './helpers.js'
 
 const sellForMoney = 'Sell for Money';
 
@@ -32,6 +32,38 @@ export function autocomplete(data, args) {
 export async function main(ns) {
     const options = getConfiguration(ns, argsSchema);
     if (!options) return; // Invalid options, or ran in --help mode.
+    let port = ns.getPortHandle(65000);
+    let tempdata = `{
+        "Spend-hacknet-hash": {
+          "liquidate": {
+            "data": "${options['liquidate'] || options.l}",
+            "dataType": "Boolean"
+          },
+          "interval": {
+            "data": "${options['interval']}",
+            "dataType": "Number"
+          },
+          "spend-on": {
+            "data": "${options['spend-on']}",
+            "dataType": "Array"
+          },
+          "spend-on-server": {
+            "data": "${options['spend-on-server']}",
+            "dataType": "String"
+          },
+          "no-capacity-upgrades": {
+            "data": "${options['no-capacity-upgrades']}",
+            "dataType": "Boolean"
+          },
+          "reserve-buffer": {
+            "data": "${options['reserve-buffer']}",
+            "dataType": "Number"
+          }
+        }
+      }
+      `
+    await portWrite(ns,port,tempdata)
+    ns.print(port.peek());
     const liquidate = options.l || options.liquidate;
     const interval = options.interval;
     const toBuy = options['spend-on'].map(s => s.replaceAll("_", " "));

--- a/stanek.js
+++ b/stanek.js
@@ -1,6 +1,6 @@
 import {
     log, disableLogs, getFilePath, getConfiguration, formatNumberShort, formatRam,
-    getNsDataThroughFile, waitForProcessToComplete, getActiveSourceFiles, instanceCount, unEscapeArrayArgs
+    getNsDataThroughFile, waitForProcessToComplete, getActiveSourceFiles, instanceCount, unEscapeArrayArgs, portRead, portWrite
 } from './helpers.js'
 
 // Default sripts called at startup and shutdown of stanek
@@ -42,6 +42,50 @@ export async function main(ns) {
     const runOptions = getConfiguration(ns, argsSchema);
     if (!runOptions || await instanceCount(ns) > 1) return; // Prevent multiple instances of this script from being started, even with different args.
     options = runOptions; // We don't set the global "options" until we're sure this is the only running instance
+    let port = ns.getPortHandle(65000);
+    let tempdata = `{
+        "Stanek": {
+          "reserved-ram": {
+            "data": "${options['reserved-ram']}",
+            "dataType": "Number"
+          },
+          "reserved-ram-ideal": {
+            "data": "${options['reserved-ram-ideal']}",
+            "dataType": "Number"
+          },
+          "max-charges": {
+            "data": "${options['max-charges']}",
+            "dataType": "Number"
+          },
+          "on-startup-script": {
+            "data": "${options['on-startup-script']}",
+            "dataType": "String"
+          },
+          "on-startup-script-args": {
+            "data": "${options['on-startup-script-args']}",
+            "dataType": "Array"
+          },
+          "on-completion-script": {
+            "data": "${options['on-completion-script']}",
+            "dataType": "String"
+          },
+          "on-completion-script-args": {
+            "data": "${options['on-completion-script-args']}",
+            "dataType": "Array"
+          },
+          "no-tail": {
+            "data": "${options['no-tail']}",
+            "dataType": "Boolean"
+          },
+          "reputation-threshold": {
+            "data": "${options['reputation-threshold']}",
+            "dataType": "Number"
+          }
+        }
+      }
+      `
+    await portWrite(ns,port,tempdata)
+    ns.print(port.peek());
     disableLogs(ns, ['sleep', 'run', 'getServerMaxRam', 'getServerUsedRam'])
 
     // Validate whether we can run

--- a/stats.js
+++ b/stats.js
@@ -1,6 +1,6 @@
 import {
     log, disableLogs, instanceCount, getConfiguration, getNsDataThroughFile, getActiveSourceFiles,
-    getStocksValue, formatNumberShort, formatMoney, formatRam
+    getStocksValue, formatNumberShort, formatMoney, formatRam, portRead, portWrite
 } from './helpers.js'
 
 const argsSchema = [
@@ -21,7 +21,26 @@ let playerInBladeburner = false, nodeMap = {}
 export async function main(ns) {
     const options = getConfiguration(ns, argsSchema);
     if (!options || await instanceCount(ns) > 1) return; // Prevent multiple instances of this script from being started, even with different args.
-
+    let port = ns.getPortHandle(65000);
+    let tempdata = `{
+        "Stats": {
+            "show-peoplekilled": {
+            "data": "${options['show-peoplekilled']}",
+            "dataType": "Boolean"
+            },
+            "hide-stocks": {
+            "data": "${options['hide-stocks']}",
+            "dataType": "Boolean"
+            },
+            "hide-RAM-utilization": {
+            "data": "${options['hide-RAM-utilization']}",
+            "dataType": "Boolean"
+            }
+        }
+      }
+      `
+    await portWrite(ns,port,tempdata)
+    ns.print(port.peek());
     const dictSourceFiles = await getActiveSourceFiles(ns, false); // Find out what source files the user has unlocked
     let resetInfo = await getNsDataThroughFile(ns, 'ns.getResetInfo()');
     const bitNode = resetInfo.currentNode;

--- a/stockmaster.js
+++ b/stockmaster.js
@@ -1,6 +1,6 @@
 import {
     instanceCount, getConfiguration, getNsDataThroughFile, runCommand, getActiveSourceFiles, tryGetBitNodeMultipliers,
-    formatMoney, formatNumberShort, formatDuration, getStockSymbols
+    formatMoney, formatNumberShort, formatDuration, getStockSymbols, portRead, portWrite
 } from './helpers.js'
 
 let disableShorts = false;
@@ -89,6 +89,102 @@ export async function main(ns) {
     ns.disableLog("ALL");
     // Extract various options from the args (globals, purchasing decision factors, pre-4s factors)
     options = runOptions; // We don't set the global "options" until we're sure this is the only running instance
+    let port = ns.getPortHandle(65000);
+    let tempdata = `
+            {
+                "Stockmaster": {
+                  "liquidate": {
+                    "data": "${options['liquidate'] || options.l}",
+                    "dataType": "Boolean"
+                  },
+                  "mock": {
+                    "data": "${options['mock']}",
+                    "dataType": "Boolean"
+                  },
+                  "noisy": {
+                    "data": "${options['noisy']}",
+                    "dataType": "Boolean"
+                  },
+                  "disable-shorts": {
+                    "data": "${options['disable-shorts']}",
+                    "dataType": "Boolean"
+                  },
+                  "reserve": {
+                    "data": "${options['reserve']}",
+                    "dataType": "Number"
+                  },
+                  "fracB": {
+                    "data": "${options['fracB']}",
+                    "dataType": "Number"
+                  },
+                  "fracH": {
+                    "data": "${options['fracH']}",
+                    "dataType": "Number"
+                  },
+                  "buy-threshold": {
+                    "data": "${options['buy-threshold']}",
+                    "dataType": "Number"
+                  },
+                  "sell-threshold": {
+                    "data": "${options['sell-threshold']}",
+                    "dataType": "Number"
+                  },
+                  "diversification": {
+                    "data": "${options['diversification']}",
+                    "dataType": "Number"
+                  },
+                  "disableHud": {
+                    "data": "${options['disableHud']}",
+                    "dataType": "Boolean"
+                  },
+                  "disable-purchase-tix-api": {
+                    "data": "${options['disable-purchase-tix-api']}",
+                    "dataType": "Boolean"
+                  },
+                  "show-pre-4s-forecast": {
+                    "data": "${options['show-pre-4s-forecast']}",
+                    "dataType": "Boolean"
+                  },
+                  "show-market-summary": {
+                    "data": "${options['show-market-summary']}",
+                    "dataType": "Boolean"
+                  },
+                  "pre-4s-buy-threshold-probability": {
+                    "data": "${options['pre-4s-buy-threshold-probability']}",
+                    "dataType": "Number"
+                  },
+                  "pre-4s-buy-threshold-return": {
+                    "data": "${options['pre-4s-buy-threshold-return']}",
+                    "dataType": "Number"
+                  },
+                  "pre-4s-sell-threshold-return": {
+                    "data": "${options['pre-4s-sell-threshold-return']}",
+                    "dataType": "Number"
+                  },
+                  "pre-4s-min-tick-history": {
+                    "data": "${options['pre-4s-min-tick-history']}",
+                    "dataType": "Number"
+                  },
+                  "pre-4s-forecast-window": {
+                    "data": "${options['pre-4s-forecast-window']}",
+                    "dataType": "Number"
+                  },
+                  "pre-4s-inversion-detection-window": {
+                    "data": "${options['pre-4s-inversion-detection-window']}",
+                    "dataType": "Number"
+                  },
+                  "pre-4s-minimum-hold-time": {
+                    "data": "${options['pre-4s-minimum-hold-time']}",
+                    "dataType": "Number"
+                  },
+                  "buy-4s-budget": {
+                    "data": "${options['buy-4s-budget']}",
+                    "dataType": "Number"
+                  }
+                }
+              }`
+    await portWrite(ns,port,tempdata)
+    ns.print(port.peek());
     mock = options.mock;
     noisy = options.noisy;
     const fracB = options.fracB;

--- a/work-for-factions.js
+++ b/work-for-factions.js
@@ -1,7 +1,7 @@
 import {
     instanceCount, getConfiguration, getNsDataThroughFile, getFilePath, getActiveSourceFiles, tryGetBitNodeMultipliers,
-    formatDuration, formatMoney, formatNumberShort, disableLogs, log
-} from './helpers.js'
+    formatDuration, formatMoney, formatNumberShort, disableLogs, log, portRead, portWrite
+} from '/helpers.js'
 
 let options;
 const argsSchema = [
@@ -9,6 +9,7 @@ const argsSchema = [
     ['skip', []], // Don't work for these factions
     ['o', false], // Immediately grind company factions for rep after getting their invite, rather than first getting all company invites we can
     ['desired-stats', []], // Factions will be removed from our 'early-faction-order' once all augs with these stats have been bought out
+    ['no-xpmode', true], // Disable using the "Xp Mode" of the daemon to speed up getting hacking xp
     ['no-focus', false], // Disable doing work that requires focusing (crime), and forces study/faction/company work to be non-focused (even if it means incurring a penalty)
     ['no-studying', false], // Disable studying.
     ['pay-for-studies-threshold', 200000], // Only be willing to pay for our studies if we have this much money
@@ -23,6 +24,9 @@ const argsSchema = [
     ['karma-threshold-for-gang-invites', -40000], // Prioritize working for gang invites once we have this much negative Karma
     ['disable-treating-gang-as-sole-provider-of-its-augs', false], // Set to true if you still want to grind for rep with factions that only have augs your gang provides
     ['no-bladeburner-check', false], // By default, will avoid working if bladeburner is active and "The Blade's Simulacrum" isn't installed
+    ['xp-mode-ram', 8192], // The minimum amount of RAM on the home server in order for xp mode to be used
+    ['xp-min-diff', 500], //the minimum difference between the current hacking level and the target hacking level for xp mode to be used
+    ['xp-max-diff', 10000], //the maximum difference between the current hacking level and the target hacking level for xp mode to be used
 ];
 
 const companySpecificConfigs = [
@@ -454,14 +458,41 @@ async function earnFactionInvite(ns, factionName) {
         !(reqHackingOrCombat.includes(factionName) && workedForInvite)) {
         ns.print(`${reasonPrefix} you have insufficient hack level. Need: ${requirement}, Have: ${player.skills.hacking}`);
         const em = requirement / options['training-stat-per-multi-threshold'];
-        if (options['no-studying'])
-            return ns.print(`--no-studying is set, nothing we can do to improve hack level.`);
+        if (options['no-studying'] && options['no-xpmode'])
+            return ns.print(`--no-studying and --no-xpmode is set, nothing we can do to improve hack level.`);
         else if (classHeuristic('hacking') < em)
             return ns.print(`Your combination of Hacking mult (${formatNumberShort(player.mults.hacking)}), exp_mult ` +
                 `(${formatNumberShort(player.mults.hacking_exp)}), and bitnode hacking / study exp mults ` +
                 `(${formatNumberShort(bitnodeMultipliers.HackingLevelMultiplier)}) / (${formatNumberShort(bitnodeMultipliers.ClassGymExpGain)}) ` +
                 `are probably too low to increase hack from ${player.skills.hacking} to ${requirement} in a reasonable amount of time ` +
                 `(${formatNumberShort(classHeuristic('hacking'))} < ${formatNumberShort(em, 2)} - configure with --training-stat-per-multi-threshold)`);
+
+
+        // Start the additional logic for xp mode. Even though at this point we know out combined hacking mult is sufficient to train hack in a reasonable amount of time,
+        // we need to make sure we have the ram for it and the it will be actually viable, otherwise xp mode will just be a waste of our time.
+        const home = await getServerinfo(ns, "home");
+        if (!options['no-xpmode'] && home.maxRam >= options['xp-mode-ram']) {
+            ns.print('Conditions met to potentally use XP mode. Beginning the additional viability checks...');
+            // Great we met the conditions now lets check to see if switching the daemon to xp mode will actually be a good idea.
+            // Lets start by getting how many hacking levels we need for our faction invite.
+            if(player.skills.hacking-requirement <= options['xp-min-diff'] || // No use in xp mode if we are going for less than 500 levels would be a waste of resources because at this point our xp mult should be fairly high
+                 player.skills.hacking-requirement >= options['xp-max-diff']) { // This condition should never occcur for a faction invite but if it does something is extremely wrong and we shouldnt restart the daemon
+                ns.print('XP mode is not viable. We are either going for too few or too many levels.');
+            }
+            else{
+                    // Great everything checks out lets calculate the time it will take to get the levels we need and switch the daemon hopefully nondestructively......
+                    // Lets start by switching the daemon to xp mode through ports
+                    let port = ns.getPortHandle(65000)
+                    ns.print('Switching daemon to xp mode...');
+                    // need to make the data for setting the daemon to xp mode
+                    let data =  '{"Daemon":{"XP Mode":{"dataType": "boolean","data": "true"}},}'
+                    await portWrite(ns, port, data);
+
+                }
+            
+            
+        }
+
         let studying = false;
         if (player.money > options['pay-for-studies-threshold']) { // If we have sufficient money, pay for the best studies
             if (player.city != "Volhaven") await goToCity(ns, "Volhaven");
@@ -700,6 +731,20 @@ export async function tryJoinFaction(ns, factionName) {
         return false;
     log(ns, `Joined faction "${factionName}"`, false, 'success');
     return true;
+}
+
+
+/**@param {NS} ns
+ * @returns {Promise<Server>} The result of ns.getServer() */
+async function getServerinfo(ns, serverName) {
+    return await getNsDataThroughFile(ns, `ns.getServer(ns.args[0])`, null, [serverName]);
+}
+
+/**@param {NS} ns
+ * @returns {Promise<String>} The result of ns.getPurchasedServer() */
+async function getPurchasedServers(ns) {
+    // This function might be useful in the future development of the xp mode logic. Still need to see how that whole thing works.
+    return await getNsDataThroughFile(ns, `ns.getPurchasedServer()`);
 }
 
 /** @param {NS} ns

--- a/work-for-factions.js
+++ b/work-for-factions.js
@@ -108,6 +108,104 @@ export async function main(ns) {
     options = runOptions; // We don't set the global "options" until we're sure this is the only running instance
     disableLogs(ns, ['sleep']);
 
+    // Adding start up args to the port
+    let port = ns.getPortHandle(65000);
+    let tempdata = `
+    {
+      "Work-for-factions": {
+        "first": {
+          "data": "${options['first']}",
+          "dataType": "array"
+        },
+        "skip": {
+          "data": "${options['skip']}",
+          "dataType": "array"
+        },
+        "o": {
+          "data": "${options.o}",
+          "dataType": "boolean"
+        },
+        "desired-stats": {
+          "data": "${options['desired-stats']}",
+          "dataType": "array"
+        },
+        "no-xpmode": {
+          "data": "${options['no-xpmode']}",
+          "dataType": "boolean"
+        },
+        "no-focus": {
+          "data": "${options['no-focus']}",
+          "dataType": "boolean"
+        },
+        "no-studying": {
+          "data": "${options['no-studying']}",
+          "dataType": "boolean"
+        },
+        "pay-for-studies-threshold": {
+          "data": "${options['pay-for-studies-threshold']}",
+          "dataType": "number"
+        },
+        "training-stat-per-multi-threshold": {
+          "data": "${options['training-stat-per-multi-threshold']}",
+          "dataType": "number"
+        },
+        "no-coding-contracts": {
+          "data": "${options['no-coding-contracts']}",
+          "dataType": "boolean"
+        },
+        "no-crime": {
+          "data": "${options['no-crime']}",
+          "dataType": "boolean"
+        },
+        "crime-focus": {
+          "data": "${options['crime-focus']}",
+          "dataType": "boolean"
+        },
+        "fast-crimes-only": {
+          "data": "${options['fast-crimes-only']}",
+          "dataType": "boolean"
+        },
+        "invites-only": {
+          "data": "${options['invites-only']}",
+          "dataType": "boolean"
+        },
+        "prioritize-invites": {
+          "data": "${options['prioritize-invites']}",
+          "dataType": "boolean"
+        },
+        "get-invited-to-every-faction": {
+          "data": "${options['get-invited-to-every-faction']}",
+          "dataType": "boolean"
+        },
+        "karma-threshold-for-gang-invites": {
+          "data": "${options['karma-threshold-for-gang-invites']}",
+          "dataType": "number"
+        },
+        "disable-treating-gang-as-sole-provider-of-its-augs": {
+          "data": "${options['disable-treating-gang-as-sole-provider-of-its-augs']}",
+          "dataType": "boolean"
+        },
+        "no-bladeburner-check": {
+          "data": "${options['no-bladeburner-check']}",
+          "dataType": "boolean"
+        },
+        "xp-mode-ram": {
+          "data": "${options['xp-mode-ram']}",
+          "dataType": "number"
+        },
+        "xp-min-diff": {
+          "data": "${options['xp-min-diff']}",
+          "dataType": "number"
+        },
+        "xp-max-diff": {
+          "data": "${options['xp-max-diff']}",
+          "dataType": "number"
+        }
+      }
+    }`
+    await portWrite(ns,port,tempdata)
+    ns.print(port.peek());
+
     // Reset globals whose value can persist between script restarts in weird situations
     lastTravel = crimeCount = 0;
     notifiedAboutDaedalus = playerInBladeburner = false;

--- a/work-for-factions.js
+++ b/work-for-factions.js
@@ -485,7 +485,7 @@ async function earnFactionInvite(ns, factionName) {
                     let port = ns.getPortHandle(65000)
                     ns.print('Switching daemon to xp mode...');
                     // need to make the data for setting the daemon to xp mode
-                    let data =  '{"Daemon":{"XP Mode":{"dataType": "boolean","data": "true"}},}'
+                    let data =  '{"Daemon":{"xp-only":{"dataType": "boolean","data": "true"}},}'
                     await portWrite(ns, port, data);
 
                 }


### PR DESCRIPTION
no pull because I accidently developed on main and git was being a bitch when I tried rebasing. 

Currently all the functions needed for script communication via ports have been added they need to be optimized and made less shitty but it works and thats all I care about. As of right now the daemon dumps all its start up settings to the port and only checks for changes with xp mode. The work for faction script also has some changes to train XP through putting the daemon in hacking mode as long as it deems it fast enough. The logic is very basic and can be improved a lot but since this use case is was thrown together as a proof of concept for this idea. 

for anyone who may want to try this out with scripts please note that the script you want to read or write data from must initialize  a port handler on port 65000 see line 405 of work-for-faction to see how this is done. There is probably a better way of doing this but for now this is the solution. 


I plan on making it so that every script dumps its start up properties upon initialization so that the can be read and modified. I need to figure out how to deal with the data once a script ends so that other scripts dont try changing its behavior expecting something to happen when nothing does.

One thing to not about ports in bit burner. From what I understand each port runs on its own thread and all operations occur on said thread meaning that operations on the port run one at a time and as long as I am correct about this it should never have 2 operations at the same time which could be extremely dangerous since most port operations are destructive and remove the data from the port.

One thing I might experiment with is using different ports for different scripts in order to improve the script performance by minimizing the queue length, but that is beyond the scope of this pull request is only to add the capabilities for the use of ports and add an example use case