### PR TITLE
#355 Be more clear when a temp script cannot be run due to RAM issues

### DIFF
--- a/daemon.js
+++ b/daemon.js
@@ -367,6 +367,11 @@ export async function main(ns) {
     await runPeriodicScripts(ns);
     if (shouldKickstartHackXp) await kickstartHackXp(ns);
 
+    // For early players, provide a hint to buy more home RAM asap:
+    if (!(4 in dictSourceFiles) && !reqRam(64))
+        log(ns, `HINT: Daemon.js can do more if you have more Home Ram. ` +
+            `Head to [alpha ent.] and purchase at 64 GB as soon as possible!`, true, 'info');
+
     // Start the main targetting loop
     await doTargetingLoop(ns);
 }


### PR DESCRIPTION
- Remind the user when daemon.js starts up if they are responsible for manually upgrading home ram!
- Check temp script ram requirement if it fails, and include it in the error message.
- Autoretry improved to not invoke the error message getter on each iteration, and to support async function parameters.