### PR TITLE
Support additional metric memory formats

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -52,9 +52,11 @@ export function formatRam(num, printGB) {
     if(printGB) {
         return `${Math.round(num).toLocaleString('en')} GB`;
     }
-    let idx = Math.floor(Math.log10(num) / 3);
+    let idx = Math.floor(Math.log10(num) / 3) || 0;
     if (idx >= memorySuffixes.length) {
         idx = memorySuffixes.length - 1;
+    } else if (idx < 0) {
+        idx = 0;
     }
     return (num / 1000 ** idx).toFixed(3).toLocaleString('en') + " " + memorySuffixes[idx];
 }

--- a/helpers.js
+++ b/helpers.js
@@ -36,7 +36,7 @@ export function parseShortNumber(text = "0") {
 }
 
 /**
- * Return a number formatted with the specified number of significatnt figures or decimal places, whichever is more limiting.
+ * Return a number formatted with the specified number of significant figures or decimal places, whichever is more limiting.
  * @param {number} num - The number to format
  * @param {number=} minSignificantFigures - (default: 6) The minimum significant figures you wish to see (e.g. 123, 12.3 and 1.23 all have 3 significant figures)
  * @param {number=} minDecimalPlaces - (default: 3) The minimum decimal places you wish to see, regardless of significant figures. (e.g. 12.3, 1.2, 0.1 all have 1 decimal)
@@ -45,8 +45,19 @@ export function formatNumber(num, minSignificantFigures = 3, minDecimalPlaces = 
     return num == 0.0 ? num : num.toFixed(Math.max(minDecimalPlaces, Math.max(0, minSignificantFigures - Math.ceil(Math.log10(num)))));
 }
 
-/** Formats some RAM amount as a round number of GB with thousands separators e.g. `1,028 GB` */
-export function formatRam(num) { return `${Math.round(num).toLocaleString('en')} GB`; }
+const memorySuffixes = ["GB", "TB", "PB", "EB"];
+
+/** Formats some RAM amount as a round number of GB/TB/PB/EB with thousands separators e.g. `1.028 TB` */
+export function formatRam(num, printGB) {
+    if(printGB) {
+        return `${Math.round(num).toLocaleString('en')} GB`;
+    }
+    let idx = Math.floor(Math.log10(num) / 3);
+    if (idx >= memorySuffixes.length) {
+        idx = memorySuffixes.length - 1;
+    }
+    return (num / 1000 ** idx).toFixed(3).toLocaleString('en') + " " + memorySuffixes[idx];
+}
 
 /** Return a datatime in ISO format */
 export function formatDateTime(datetime) { return datetime.toISOString(); }

--- a/stats.js
+++ b/stats.js
@@ -255,7 +255,7 @@ async function getHudData(ns, bitNode, dictSourceFiles, options) {
             // Add Home RAM and Utilization
             val2.push(true, `${formatRam(home.maxRam)} ${(100 * home.ramUsed / home.maxRam).toFixed(1)}%`,
                 `Shows total home RAM (and current utilization %)\nDetails: ${home.cpuCores} cores and using ` +
-                `${formatRam(home.ramUsed)} of ${formatRam(home.maxRam)} (${formatRam(home.maxRam - home.ramUsed)} free)`);
+                `${formatRam(home.ramUsed, true)} of ${formatRam(home.maxRam, true)} (${formatRam(home.maxRam - home.ramUsed, true)} free)`);
             // If the user has any scripts running on hacknet servers, assume they want them included in available RAM stats
             const includeHacknet = likelyHacknet.some(s => s.ramUsed > 0);
             const [totalMax, totalUsed] = servers.filter(s => s.hasAdminRights && (includeHacknet || !s.hostname.startsWith("hacknet-node-")))
@@ -264,7 +264,7 @@ async function getHudData(ns, bitNode, dictSourceFiles, options) {
             val3.push(true, `${formatRam(totalMax)} ${(100 * totalUsed / totalMax).toFixed(1)}%`,
                 `Shows the sum-total RAM and utilization across all rooted hosts on the network` + (9 in dictSourceFiles || 9 == bitNode ?
                     (includeHacknet ? "\n(including hacknet servers, because you have scripts running on them)" : " (excluding hacknet servers)") : "") +
-                `\nDetails: Using ${formatRam(totalUsed)} of ${formatRam(totalMax)} (${formatRam(totalMax - totalUsed)} free)`);
+                `\nDetails: Using ${formatRam(totalUsed, true)} of ${formatRam(totalMax, true)} (${formatRam(totalMax - totalUsed, true)} free)`);
         } else {
             val1.push(false)
             val2.push(false)


### PR DESCRIPTION
This is a simple change to format the printed memory numbers in Tera-, Peta- and Exabytes to make some logs and stats slightly more concise.

Mouse-over memory information in the stats view is still printed in GB so the full amount is still visible if needed.
