### PR TITLE
adjust rep requirement for promotion when company server is backdoored

### DIFF
--- a/work-for-factions.js
+++ b/work-for-factions.js
@@ -1111,7 +1111,7 @@ export async function workForMegacorpFactionInvite(ns, factionName, waitForInvit
         const requiredCha = nextJob.reqCha[nextJobTier] === 0 ? 0 : nextJob.reqCha[nextJobTier] + statModifier; // Stat modifier only applies to non-zero reqs
         const requiredRep = nextJob.reqRep[nextJobTier] * (backdoored ? 0.75 : 1); // Rep requirement is decreased when company server is backdoored
         let status = `Next promotion ('${nextJobName}' #${nextJobTier}) at Hack:${requiredHack} Cha:${requiredCha} Rep:${requiredRep?.toLocaleString('en')}` +
-            (repRequiredForFaction > nextJob.reqRep[nextJobTier] ? '' : `, but we won't need it, because we'll sooner hit ${repRequiredForFaction.toLocaleString('en')} reputation to unlock company faction "${factionName}"!`);
+            (repRequiredForFaction > requiredRep ? '' : `, but we won't need it, because we'll sooner hit ${repRequiredForFaction.toLocaleString('en')} reputation to unlock company faction "${factionName}"!`);
         // Monitor that we are still performing the expected work
         let currentWork = await getCurrentWorkInfo(ns);
         // We should only study at university if every other requirement is met but Charisma

--- a/work-for-factions.js
+++ b/work-for-factions.js
@@ -1109,7 +1109,7 @@ export async function workForMegacorpFactionInvite(ns, factionName, waitForInvit
         const nextJob = nextJobName == "it" ? itJob : softwareJob;
         const requiredHack = nextJob.reqHack[nextJobTier] === 0 ? 0 : nextJob.reqHack[nextJobTier] + statModifier; // Stat modifier only applies to non-zero reqs
         const requiredCha = nextJob.reqCha[nextJobTier] === 0 ? 0 : nextJob.reqCha[nextJobTier] + statModifier; // Stat modifier only applies to non-zero reqs
-        const requiredRep = nextJob.reqRep[nextJobTier]; // No modifier on rep requirements
+        const requiredRep = nextJob.reqRep[nextJobTier] * (backdoored ? 0.75 : 1); // Rep requirement is decreased when company server is backdoored
         let status = `Next promotion ('${nextJobName}' #${nextJobTier}) at Hack:${requiredHack} Cha:${requiredCha} Rep:${requiredRep?.toLocaleString('en')}` +
             (repRequiredForFaction > nextJob.reqRep[nextJobTier] ? '' : `, but we won't need it, because we'll sooner hit ${repRequiredForFaction.toLocaleString('en')} reputation to unlock company faction "${factionName}"!`);
         // Monitor that we are still performing the expected work


### PR DESCRIPTION
I noticed that the work-for-faction script was slightly off when calculating the required reputation for the next promotion.
Apparently, there's a modified applied to job reputation when the company server is backdoored which is not yet considered by the script.
https://github.com/bitburner-official/bitburner-src/blob/dev/src/Constants.ts#L108

![2024-10-25_23-37](https://github.com/user-attachments/assets/12f0a66a-11d1-4465-bcce-56a7683d655f)
