### PR TITLE
Update job stat requirement offsets

### DIFF
--- a/work-for-factions.js
+++ b/work-for-factions.js
@@ -29,6 +29,12 @@ const companySpecificConfigs = [
     { name: "NWO", statModifier: 249 },
     { name: "MegaCorp", statModifier: 249 },
     { name: "Blade Industries", statModifier: 224 },
+    { name: "Bachman & Associates", statModifier: 224 },
+    { name: "ECorp", statModifier: 249 },
+    { name: "Clarke Incorporated", statModifier: 224 },
+    { name: "OmniTek Incorporated", statModifier: 224 },
+    { name: "KuaiGong International", statModifier: 224 },
+    { name: "Four Sigma", statModifier: 224 },
     { name: "Fulcrum Secret Technologies", companyName: "Fulcrum Technologies", statModifier: 224 }, // Special snowflake
     { name: "Silhouette", companyName: "TBD", repRequiredForFaction: 1.0e7 } // Hack: 3.2e6 should be enough rep to get the CTO position, but once
     // we hit this rep we might break out of the work loop before getting the final promotion, so we keep working until we get the faction invite.

--- a/work-for-factions.js
+++ b/work-for-factions.js
@@ -26,10 +26,10 @@ const argsSchema = [
 ];
 
 const companySpecificConfigs = [
-    { name: "NWO", statModifier: 25 },
-    { name: "MegaCorp", statModifier: 25 },
-    { name: "Blade Industries", statModifier: 25 },
-    { name: "Fulcrum Secret Technologies", companyName: "Fulcrum Technologies" }, // Special snowflake
+    { name: "NWO", statModifier: 249 },
+    { name: "MegaCorp", statModifier: 249 },
+    { name: "Blade Industries", statModifier: 224 },
+    { name: "Fulcrum Secret Technologies", companyName: "Fulcrum Technologies", statModifier: 224 }, // Special snowflake
     { name: "Silhouette", companyName: "TBD", repRequiredForFaction: 1.0e7 } // Hack: 3.2e6 should be enough rep to get the CTO position, but once
     // we hit this rep we might break out of the work loop before getting the final promotion, so we keep working until we get the faction invite.
 ]


### PR DESCRIPTION
Update job stat offsets values after comparing it to src  https://github.com/bitburner-official/bitburner-src/blob/dev/src/Company/data/CompaniesMetadata.ts#L35 

I also noticed that there were some offsets missing for companies on the `preferredCompanyFactionOrder` list, so I added them. :) 

Not sure but this might fix #415 