### PR TITLE
Disable WD hack priority when required hack level is achieved

### DIFF
--- a/autopilot.js
+++ b/autopilot.js
@@ -323,7 +323,7 @@ async function checkIfBnIsComplete(ns, player) {
     // HEURISTIC: If we naturally get within 75% of the if w0r1d_d43m0n hack stat requirement,
     //    switch daemon.js to prioritize earning hack exp for the remainder of the BN
     if (player.skills.hacking >= (wdHack * 0.75))
-        prioritizeHackForWd = true;
+        prioritizeHackForWd = !bnComplete;
 
     if (!bnComplete) return false; // No win conditions met
 


### PR DESCRIPTION
I noticed at the end of BN10 that the daemon continued in `xp-only` mode even though the hack level was already way beyond the WD requirement.
Since in BN10 we don't auto-destroy the BN on completion, the autopilot script would never switch the heuristic back so it always focuses on xp earning.
This change simply disables the "focus on xp-earning for WD completion" if the required hack level has already been reached.