### PR TITLE
Move tail APIs for 2.8.0

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -848,7 +848,7 @@ export function unEscapeArrayArgs(args) {
 export function tail(ns, processId = undefined) {
     checkNsInstance(ns, '"tail"');
     processId ??= ns.pid
-    ns.tail(processId);
+    ns.ui.tail(processId);
     // Don't move or resize tail windows that were previously opened and possibly moved by the player
     const tailFile = '/Temp/helpers-tailed-pids.txt'; // Use a file so it can be wiped on reset
     const fileContents = ns.read(tailFile);
@@ -857,11 +857,11 @@ export function tail(ns, processId = undefined) {
         return //ns.tprint(`PID was previously moved ${processId}`);
     // By default, make all tail windows take up 75% of the width, 25% of the height available
     const [width, height] = ns.ui.windowSize();
-    ns.resizeTail(width * 0.60, height * 0.25, processId);
+    ns.ui.resizeTail(width * 0.60, height * 0.25, processId);
     // Cascade windows: After each tail, shift the window slightly down and over so that they don't overlap
     let offsetPct = ((((tailedPids.length % 30.0) / 30.0) + tailedPids.length) % 6.0) / 6.0;
     ns.print(width, ' ', height, ' ', processId, ' ', offsetPct, ' ', tailedPids)
-    ns.moveTail(offsetPct * (width * 0.25 - 300) + 250, offsetPct * (height * 0.75 - 100) + 50, processId);
+    ns.ui.moveTail(offsetPct * (width * 0.25 - 300) + 250, offsetPct * (height * 0.75 - 100) + 50, processId);
     tailedPids.push(processId);
     ns.write(tailFile, JSON.stringify(tailedPids), 'w');
 }


### PR DESCRIPTION
Move tail-related APIs to ns.ui namespace due to deprecation.