### PR TITLE
go.js - Removed Netburners from list of opponents when in BN 8

### DIFF
--- a/go.js
+++ b/go.js
@@ -87,7 +87,8 @@ export async function main(ns) {
     const opponent = ["Netburners", "Slum Snakes", "The Black Hand", "Tetrads", "Daedalus", "Illuminati"];
     const opponent2 = ["Netburners", "Slum Snakes", "The Black Hand", "Tetrads", "Daedalus", "Illuminati", "????????????"];
 
-    if (ns.getResetInfo() == 8) {
+    let resetInfo = await getNsDataThroughFile(ns, 'ns.getResetInfo()');
+    if (resetInfo.currentNode == 8) {
         opponent.splice(index, 0);
         opponent2.splice(index, 0);
     }

--- a/go.js
+++ b/go.js
@@ -87,6 +87,11 @@ export async function main(ns) {
     const opponent = ["Netburners", "Slum Snakes", "The Black Hand", "Tetrads", "Daedalus", "Illuminati"];
     const opponent2 = ["Netburners", "Slum Snakes", "The Black Hand", "Tetrads", "Daedalus", "Illuminati", "????????????"];
 
+    if (ns.getResetInfo() == 8) {
+        opponent.splice(index, 0);
+        opponent2.splice(index, 0);
+    }
+
     await start();
 
     /** @param {NS} ns */


### PR DESCRIPTION
go.js should not play against Netburners in BN 8, as hacknet nodes do not produce money there.