### PR TITLE
Fix #470 - Revert "go.js - Removed Netburners from list of opponents when in BN 8"

### DIFF
--- a/go.js
+++ b/go.js
@@ -87,12 +87,6 @@ export async function main(ns) {
     const opponent = ["Netburners", "Slum Snakes", "The Black Hand", "Tetrads", "Daedalus", "Illuminati"];
     const opponent2 = ["Netburners", "Slum Snakes", "The Black Hand", "Tetrads", "Daedalus", "Illuminati", "????????????"];
 
-    let resetInfo = await getNsDataThroughFile(ns, 'ns.getResetInfo()');
-    if (resetInfo.currentNode == 8) {
-        opponent.splice(index, 0);
-        opponent2.splice(index, 0);
-    }
-
     await start();
 
     /** @param {NS} ns */


### PR DESCRIPTION
Reverts alainbryden/bitburner-scripts#468