### PR TITLE
MISC: Explicitly convert absolute-reserve arg of host-manager.js to number

### DIFF
--- a/host-manager.js
+++ b/host-manager.js
@@ -88,7 +88,7 @@ export async function main(ns) {
     if (!keepRunning)
         log(ns, `host-manager will run once. Run with argument "-c" to run continuously.`)
     do {
-        absReservedMoney = options['absolute-reserve'] != null ? options['absolute-reserve'] : Number(ns.read("reserve.txt") || 0);
+        absReservedMoney = options['absolute-reserve'] != null ? Number(options['absolute-reserve']) : Number(ns.read("reserve.txt") || 0);
         await tryToBuyBestServerPossible(ns);
         if (keepRunning)
             await ns.sleep(options['interval']);


### PR DESCRIPTION
While testing #482, I occasionally see the warning from `formatNumberShort` (`formatNumberShort called with "num" set to a non-numeric `). This happens when `daemon.js` runs `host-manager.js`. The value passed to `--absolute-reserve` is a number, but after reading it with `ns.flags` (via `getConfiguration`), it becomes a string. `ns.flags` has a special behavior when the schema does not define a default value for an arg. For example:
```js
/** @param {NS} ns */
export async function main(ns) {
  const schema = [
    ['foo', 1000],
    ['bar', null]
  ];
  console.log(ns.flags(schema));
}
```
If you run `run test.js --foo 1 --bar 2`, `ns.flags(schema)` is:
```
{_: Array(0), foo: 1, bar: '2'}
```
`bar` is `"2"` (a string), not `2` (a number).

It's even worse if you try to pass a boolean: `run test.js --foo 1 --bar false`. `ns.flags(schema)` is:
```
{_: Array(0), foo: 1, bar: 'false'}
```
`bar` is a string instead of a boolean. This will mess up any logical operations involving `bar`. For example, `!!ns.flags(schema).bar` is true.

You may need to check other files to see if this is a problem in those files.