### PR TITLE
CCT: Remove unnecessary string conversion

### DIFF
--- a/Tasks/contractor.js.solver.js
+++ b/Tasks/contractor.js.solver.js
@@ -99,18 +99,8 @@ function findAnswer(contract) {
     return codingContractSolution ? codingContractSolution.solver(JSON.parse(contract.dataJson, jsonReviver)) : null;
 }
 
-function convert2DArrayToString(arr) {
-    const components = []
-    arr.forEach(function (e) {
-        let s = e.toString()
-        s = ['[', s, ']'].join('')
-        components.push(s)
-    })
-    return components.join(',').replace(/\s/g, '')
-}
-
 // Based on https://github.com/danielyxie/bitburner/blob/master/src/data/codingcontracttypes.ts
-const codingContractTypesMetadata = [{
+export const codingContractTypesMetadata = [{
     name: 'Find Largest Prime Factor',
     solver: function (data) {
         let fac = 2
@@ -272,8 +262,7 @@ const codingContractTypesMetadata = [{
             }
         }
         result.push([start, end])
-        const sanitizedResult = convert2DArrayToString(result)
-        return sanitizedResult
+        return result;
     },
 },
 {
@@ -300,7 +289,7 @@ const codingContractTypesMetadata = [{
                 }
             }
         }
-        return ret.toString(); // Answer expected is the string representation of this array
+        return ret;
     },
 },
 {
@@ -312,7 +301,7 @@ const codingContractTypesMetadata = [{
             maxCur = Math.max(0, (maxCur += data[i] - data[i - 1]))
             maxSoFar = Math.max(maxCur, maxSoFar)
         }
-        return maxSoFar.toString()
+        return maxSoFar;
     },
 },
 {
@@ -322,7 +311,7 @@ const codingContractTypesMetadata = [{
         for (let p = 1; p < data.length; ++p) {
             profit += Math.max(data[p] - data[p - 1], 0)
         }
-        return profit.toString()
+        return profit;
     },
 },
 {
@@ -338,7 +327,7 @@ const codingContractTypesMetadata = [{
             release1 = Math.max(release1, hold1 + price)
             hold1 = Math.max(hold1, price * -1)
         }
-        return release2.toString()
+        return release2;
     },
 },
 {
@@ -712,7 +701,7 @@ const codingContractTypesMetadata = [{
         while (!oddCycleFound && solution.some(e => e === undefined)) {
             traverse(solution.indexOf(undefined), 0)
         }
-        if (oddCycleFound) return "[]"; // TODO: Bug #3755 in bitburner requires a string literal. Will this be fixed?
+        if (oddCycleFound) return [];
         return solution
     },
 },


### PR DESCRIPTION
Context: https://github.com/bitburner-official/bitburner-src/pull/2608, https://github.com/bitburner-official/bitburner-src/pull/2689

We recommend submitting the answer as-is. All old bugs related to answer format were fixed.

Note that the change to the `Generate IP Addresses` contract solver is mandatory. Please check the doc change in PR 2689 (Bitburner repository) for more information.

This PR is compatible with v2.8.1 and v3.

Test code:
```js
import { codingContractTypesMetadata } from "./Tasks/contractor.js.solver.js";

/** @param {NS} ns */
export async function main(ns) {
  console.clear();
  for (const name of Object.values(ns.enums.CodingContractName)) {
    const metadata = codingContractTypesMetadata.find((v) => v.name === name);
    if (metadata == null) {
      continue;
    }
    const now = performance.now();
    const maxIters = name === "Find All Valid Math Expressions" ? 50 : 10000;
    for (let i = 0; i < maxIters; ++i) {
      const filename = ns.codingcontract.createDummyContract(name);
      if (filename == null) {
        continue;
      }
      const data = ns.codingcontract.getData(filename);
      const answer = metadata.solver(data);
      if (ns.codingcontract.attempt(answer, filename) !== "No reward for this contract") {
        console.log(name, filename, data, answer);
        throw new Error();
      }
    }
    console.log(name, performance.now() - now);
  }
}
```