### PR TITLE
Add complete RAM-dodged darknet automation package (/darkweb/)

### DIFF
--- a/darkweb/dnet-crack.js
+++ b/darkweb/dnet-crack.js
@@ -1,0 +1,1399 @@
+// /darkweb/dnet-crack.js — RAM-dodged darknet cracker for all 25 password models
+// ZERO direct ns.dnet.* calls in main body — all routed through rd() temp scripts.
+// In-game RAM: ~3-4 GB (vs 15+ GB for direct-call approach).
+// Source-confirmed model catalog, fixed EU country list, fixed BigMo%od formula.
+//
+// Usage:
+//   run /darkweb/dnet-crack.js <hostname> [--scrape] [--copy-home] [--tail]
+
+/** @param {NS} ns */
+export async function main(ns) {
+  ns.disableLog("ALL");
+
+  const target = String(ns.args[0] ?? "");
+  if (!target || target.startsWith("-")) {
+    ns.tprint("Usage: run /darkweb/dnet-crack.js <hostname> [--scrape] [--copy-home] [--tail]");
+    return;
+  }
+
+  const HOST = ns.getHostname();
+  const HOME = "home";
+  const SELF = ns.getScriptName();
+  const DIR = dirname(SELF);
+  const path = name => DIR ? `${DIR}/${name}` : name;
+
+  const CRAWL  = path("dnet-crawl.js");
+  const CRACK  = path("dnet-crack.js");
+  const OPS    = path("dnet-ops.js");
+  const SCRAPE = path("dnet-scrape.js");
+  const ROUTE  = path("dnet-route.js");
+  const LAB    = path("dnet-lab.js");
+
+  const LEDGER  = "/darkweb/dnet-passwords.txt";
+  const MAP     = "/darkweb/dnet-map.txt";
+  const UNKNOWN = "/darkweb/dnet-unknown.txt";
+  const LOCK    = `${DIR || "/darkweb"}/dnet-crack-lock-${safeFileName(target)}.txt`;
+  const LOCK_TTL_MS = 120_000;
+
+  const RD_TIMEOUT_MS = getFlagNumber(ns, ["--rd-timeout"], 8_000);
+  const KEEP_RD    = hasArg(ns, "--keep-rd");
+  const ENABLE_SCRAPE = hasArg(ns, "--scrape");
+  const COPY_HOME  = hasArg(ns, "--copy-home");
+
+  if (hasArg(ns, "--tail")) {
+    try { ns.ui.openTail(); } catch (_) {}
+  }
+
+  if (!acquireTargetLock()) {
+    ns.print(`[DNET-CRACK] Lock exists for ${target}; another cracker is already working it.`);
+    return;
+  }
+
+  try {
+    if (HOST !== HOME) await pullLedgerFromHome();
+
+    // Try existing password from ledger first
+    const known = readLedger().get(target);
+    if (known) {
+      const conn = await rdConnect(target, known.password);
+      if (conn?.success || conn === true) {
+        ns.print(`[DNET-CRACK] Reused ledger password for ${target}`);
+        await spread(target, known.password);
+        return;
+      }
+    }
+
+    // Get server details via rd()
+    const details = await rdDetails(target);
+    if (!details) {
+      ns.print(`[DNET-CRACK] getServerDetails failed for ${target}; may be offline or unreachable`);
+      return;
+    }
+    if (!details.isOnline || !details.isConnectedToCurrentServer) {
+      ns.print(`[DNET-CRACK] ${target} offline/not adjacent`);
+      return;
+    }
+    if (details.hasSession) {
+      ns.print(`[DNET-CRACK] ${target} already has session`);
+      await spread(target, "");
+      return;
+    }
+
+    const model = String(details.modelId ?? "");
+    const len   = Number(details.passwordLength ?? 0);
+    const hint  = String(details.passwordHint ?? "");
+    const data  = String(details.data ?? details.passwordHintData ?? "");
+    const fmt   = String(details.passwordFormat ?? "").toLowerCase();
+
+    ns.print(`[DNET-CRACK] Cracking ${target} model=${model} len=${len || "?"} fmt=${fmt || "?"}`);
+    ns.print(`[DNET-CRACK] hint=${JSON.stringify(hint)} data=${JSON.stringify(data).slice(0, 200)}`);
+
+    // Labyrinth — delegate entirely to dnet-lab.js (needs a single-PID session)
+    if (model === "(The Labyrinth)") {
+      ns.print(`[DNET-CRACK] Delegating labyrinth to ${LAB}`);
+      ns.exec(LAB, HOST, { preventDuplicates: true }, target,
+        ...(hasArg(ns, "--tail") ? ["--tail"] : []));
+      return;
+    }
+
+    let result = { success: false };
+
+    switch (model) {
+      case "ZeroLogon":
+        result = await tryPw(target, "", model); break;
+      case "DeskMemo_3.1":
+        result = await crackEcho(target, model, len, hint, data); break;
+      case "PHP 5.4":
+        result = await crackSortedEcho(target, model, len, data, hint); break;
+      case "FreshInstall_1.0":
+        result = await tryCandidates(target, DEFAULTS, model, len, "default passwords"); break;
+      case "CloudBlare":
+      case "CloudBlare(tm)":
+        result = await crackCaptcha(target, model, len, hint, data); break;
+      case "Laika4":
+        result = await tryCandidates(target, DOGS, model, len, "dog names"); break;
+      case "TopPass":
+        result = await tryCandidates(target, COMMON_PASSWORDS, model, len, "common passwords"); break;
+      case "EuroZone Free":
+        result = await crackEuroZone(target, model, len); break;
+      case "BellaCuore":
+        result = await crackRoman(target, model, hint, data); break;
+      case "PrimeTime 2":
+        result = await crackLargestPrime(target, model, hint, data); break;
+      case "AccountsManager_4.2":
+        result = await crackGuessNumber(target, model, len, hint); break;
+      case "110100100":
+        result = await crackBinary(target, model, len, hint, data); break;
+      case "OrdoXenos":
+        result = await crackXor(target, model, len, hint, data); break;
+      case "OctantVoxel":
+        result = await crackBase10(target, model, hint, data); break;
+      case "MathML":
+        result = await crackMath(target, model, hint, data); break;
+      case "Pr0verFl0":
+        result = await crackBufferOverflow(target, model, len, hint); break;
+      case "2G_cellular":
+        result = await crackTimingAttack(target, model, len, fmt); break;
+      case "DeepGreen":
+        result = await crackDeepGreen(target, model, len, fmt); break;
+      case "NIL":
+        result = await crackNil(target, model, len, fmt); break;
+      case "Factori-Os":
+        result = await crackDivisibility(target, model, len); break;
+      case "BigMo%od":
+        result = await crackBigMo(target, model, len); break;
+      case "OpenWebAccessPoint":
+      case "OpenWebAccessPoiont":
+        result = await crackOpenWeb(target, model, len, fmt, hint, data); break;
+      case "KingOfTheHill":
+        result = await crackKingOfTheHill(target, model, len); break;
+      case "RateMyPix.Auth":
+        result = await crackRateMyPix(target, model, len, fmt, hint, data); break;
+      default:
+        result = await crackGeneric(target, model, len, hint, data);
+    }
+
+    if (!result.success) {
+      const hb = await rdHeartbleed(target);
+      await dumpUnknown(target, details, hb?.logs ?? []);
+      return;
+    }
+
+    await recordPassword(target, result.password, model);
+    if (HOST !== HOME) await pushLedgerToHome();
+    await spread(target, result.password);
+
+  } finally {
+    releaseTargetLock();
+  }
+
+  // ════════════════════════════════════════════════════════════════════════════
+  // rd() RAM-dodge engine — the reason this file is ~3 GB instead of 15+ GB
+  // ════════════════════════════════════════════════════════════════════════════
+
+  async function rd(label, expr, args = [], timeoutMs = RD_TIMEOUT_MS) {
+    const token = `${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+    const safeLabel = String(label || "rd").replace(/[^a-zA-Z0-9_-]/g, "_");
+    const tempDir = DIR ? `${DIR}/Temp` : "/Temp";
+    const sf = `${tempDir}/dnet-rd-${safeLabel}-${token}.js`;
+    const of = `${tempDir}/dnet-rd-${safeLabel}-${token}.txt`;
+
+    const src = `/** @param {NS} ns */
+export async function main(ns) {
+  const outFile = ns.args[0];
+  const args = ns.args.slice(1).map(a => { try { return JSON.parse(a); } catch (_) { return a; } });
+  try {
+    const result = await (async () => (${expr}))();
+    await ns.write(outFile, JSON.stringify({ ok: true, result }), "w");
+  } catch (e) {
+    await ns.write(outFile, JSON.stringify({ ok: false, error: String(e) }), "w");
+  }
+}`;
+
+    try { await ns.write(sf, src, "w"); await ns.write(of, "", "w"); }
+    catch (e) { ns.print(`[RD] write failed ${safeLabel}: ${e}`); return null; }
+
+    const pid = ns.exec(sf, HOST, 1, of, ...args.map(a => JSON.stringify(a)));
+    if (!pid) {
+      ns.print(`[RD] exec failed ${sf} — not enough free RAM?`);
+      if (!KEEP_RD) { try { ns.rm(sf, HOST); } catch (_) {} }
+      return null;
+    }
+
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline && ns.isRunning(pid)) await ns.sleep(25);
+    if (ns.isRunning(pid)) {
+      try { ns.kill(pid); } catch (_) {}
+      if (!KEEP_RD) { try { ns.rm(sf, HOST); } catch (_) {} try { ns.rm(of, HOST); } catch (_) {} }
+      ns.print(`[RD] timeout ${safeLabel} (${timeoutMs}ms)`);
+      return null;
+    }
+
+    let raw = "";
+    try { raw = ns.read(of); } catch (_) {}
+    if (!KEEP_RD) { try { ns.rm(sf, HOST); } catch (_) {} try { ns.rm(of, HOST); } catch (_) {} }
+
+    if (!raw) return null;
+    try {
+      const p = JSON.parse(raw);
+      if (!p.ok) { ns.print(`[RD] error ${safeLabel}: ${p.error}`); return null; }
+      return p.result;
+    } catch (e) { ns.print(`[RD] parse error ${safeLabel}: ${raw.slice(0, 100)}`); return null; }
+  }
+
+  // ── dnet API wrappers (all via rd()) ──────────────────────────────────────
+
+  // Returns { success, code, message, data } or null
+  async function rdRaw(host, pw) {
+    return rd("raw", `(async()=>{try{const r=await ns.dnet.authenticate(args[0],args[1]);return{success:!!r?.success,code:r?.code??0,message:String(r?.message??""),data:r?.data??null}}catch(e){return{success:false,error:String(e)}}})()`, [host, pw]);
+  }
+
+  async function rdAuth(host, pw) {
+    const r = await rdRaw(host, pw);
+    if (r?.success) return r;
+    return { success: false };
+  }
+
+  async function rdHeartbleed(host) {
+    const r = await rd("hb", `ns.dnet.heartbleed(args[0],{peek:true})`, [host], RD_TIMEOUT_MS * 2);
+    return { logs: r?.logs ?? [] };
+  }
+
+  async function rdDetails(host) {
+    return rd("details", `ns.dnet.getServerDetails(args[0])`, [host]);
+  }
+
+  async function rdConnect(host, pw) {
+    return rd("session", `ns.dnet.connectToSession(args[0],args[1])`, [host, pw]);
+  }
+
+  // ── Common attempt helpers ─────────────────────────────────────────────────
+
+  async function tryPw(host, pw, model, source = "") {
+    const r = await rdAuth(host, String(pw ?? ""));
+    if (r?.success) {
+      ns.print(`[DNET-CRACK] CRACKED ${host} pw="${pw}" model=${model}${source ? ` via ${source}` : ""}`);
+      return { success: true, password: String(pw ?? ""), model };
+    }
+    return { success: false };
+  }
+
+  async function tryCandidates(host, candidates, model, requiredLen, source = "") {
+    const list = cleanCandidates(candidates, requiredLen);
+    if (list.length) ns.print(`[DNET-CRACK] ${model}: trying ${list.length} candidates${source ? ` (${source})` : ""}`);
+    let count = 0;
+    for (const pw of list) {
+      const r = await tryPw(host, pw, model, source);
+      if (r.success) return r;
+      if (++count % 250 === 0) await ns.sleep(0);
+    }
+    return { success: false };
+  }
+
+  // ════════════════════════════════════════════════════════════════════════════
+  // Model solvers
+  // ════════════════════════════════════════════════════════════════════════════
+
+  // ZeroLogon — NoPassword: password is always ""
+  // (handled inline above as tryPw(target, ""))
+
+  // DeskMemo_3.1 — EchoVuln: password is getPassword(3), shown plainly in hint
+  async function crackEcho(host, model, len, hint, data) {
+    const candidates = [...extractNumbers(hint), ...extractNumbers(data)];
+    if (len) { candidates.push(hint.slice(-len), data.slice(-len)); }
+    return tryCandidates(host, candidates, model, len, "echo hint");
+  }
+
+  // PHP 5.4 — SortedEchoVuln: sorted digits of password are in hint/data
+  async function crackSortedEcho(host, model, len, data, hint) {
+    const sorted = (data || extractNumbers(hint).sort((a, b) => b.length - a.length)[0] || "")
+      .replace(/[^0-9]/g, "");
+    if (!sorted) return { success: false };
+    const passLen = len || sorted.length;
+    ns.print(`[DNET-CRACK] PHP 5.4 sorted="${sorted}" len=${passLen}`);
+    let count = 0;
+    for (const p of uniquePermutations(sorted, 500_000)) {
+      if (p.length !== passLen) continue;
+      if (p.length > 1 && p.startsWith("0")) continue;
+      const r = await tryPw(host, p, model, "sorted permutation");
+      if (r.success) return r;
+      if (++count % 250 === 0) await ns.sleep(0);
+    }
+    ns.print(`[DNET-CRACK] PHP 5.4 exhausted ${count} permutations`);
+    return { success: false };
+  }
+
+  // CloudBlare(tm) — Captcha: numeric password, digits appear in data (filler chars stripped)
+  async function crackCaptcha(host, model, len, hint, data) {
+    const candidates = [digitsOnly(data, len), digitsOnly(hint, len),
+      ...extractNumbers(data), ...extractNumbers(hint)];
+    return tryCandidates(host, candidates, model, len || undefined, "captcha digits");
+  }
+
+  // EuroZone Free — EUCountryDictionary: exact country name from source list
+  // FIXED: "Republic of Cyprus" (not "Cyprus"), "Czech Republic" (not "Czechia"),
+  //        "Netherlands" (not "The Netherlands") — source-exact from dictionaryData.ts
+  async function crackEuroZone(host, model, len) {
+    const all = [];
+    for (const country of EU_COUNTRIES) all.push(...countryVariants(country));
+    const passLen = Number(len || 0);
+    const byLen  = passLen > 0 ? all.filter(p => p.length === passLen) : [];
+    const rest   = passLen > 0 ? all.filter(p => !byLen.includes(p)) : all;
+    ns.print(`[DNET-CRACK] EuroZone: ${byLen.length} length-match + ${rest.length} fallback`);
+    const r = await tryCandidates(host, byLen, model, undefined, "EU length-match");
+    if (r.success) return r;
+    return tryCandidates(host, rest, model, undefined, "EU full list");
+  }
+
+  // BellaCuore — RomanNumeral: diff<8: single Roman numeral; diff≥8: range with feedback
+  // Feedback: "PARUM BREVIS" = too low, "ALTUS NIMIS" = too high
+  async function crackRoman(host, model, hint, data) {
+    const text = `${hint}\n${data}`;
+    const pair = parseRomanRange(text);
+
+    if (pair) {
+      const lo0 = Math.max(0, Math.min(pair[0], pair[1]));
+      const hi0 = Math.max(pair[0], pair[1]);
+      let lo = lo0, hi = hi0;
+      const tried = new Set();
+      ns.print(`[DNET-CRACK] BellaCuore binary search ${lo0}..${hi0}`);
+
+      while (lo <= hi) {
+        const mid = Math.floor((lo + hi) / 2);
+        tried.add(String(mid));
+        const raw = await rdRaw(host, String(mid));
+        if (raw?.success) return { success: true, password: String(mid), model };
+        const fb = parseBellaFeedback(raw);
+        ns.print(`[DNET-CRACK] BellaCuore ${mid} → ${fb || "?"}`);
+        if (fb === "low")  lo = mid + 1;
+        else if (fb === "high") hi = mid - 1;
+        else break;
+        await ns.sleep(0);
+      }
+      // Sweep narrowed window then full range as fallback
+      for (let n = Math.max(lo0, lo - 3); n <= Math.min(hi0, hi + 3); n++) {
+        if (tried.has(String(n))) continue;
+        const r = await tryPw(host, String(n), model, "roman binary final");
+        if (r.success) return r;
+      }
+      for (let n = lo0; n <= hi0; n++) {
+        if (tried.has(String(n))) continue;
+        const r = await tryPw(host, String(n), model, "roman range sweep");
+        if (r.success) return r;
+        if (n % 250 === 0) await ns.sleep(0);
+      }
+      return { success: false };
+    }
+
+    for (const token of extractRomanTokens(text)) {
+      const value = romanToInt(token);
+      if (value === null) continue;
+      const r = await tryPw(host, String(value), model, "roman direct");
+      if (r.success) return r;
+    }
+    return { success: false };
+  }
+
+  // PrimeTime 2 — LargestPrimeFactor: find largest prime factor of number in hint/data
+  async function crackLargestPrime(host, model, hint, data) {
+    const nums = extractNumbers(`${data}\n${hint}`).map(Number).filter(Number.isFinite).sort((a, b) => b - a);
+    for (const n of nums) {
+      const factor = largestPrimeFactor(n);
+      if (!factor) continue;
+      const r = await tryPw(host, String(factor), model, `largest prime of ${n}`);
+      if (r.success) return r;
+    }
+    return { success: false };
+  }
+
+  // AccountsManager_4.2 — GuessNumber: binary search with "Higher"/"Lower" feedback
+  async function crackGuessNumber(host, model, len, hint) {
+    const maxFromHint = Number((hint.match(/between\s+0\s+and\s+(\d+)/i) ?? [])[1]);
+    const max = Number.isFinite(maxFromHint) && maxFromHint > 0
+      ? maxFromHint
+      : 10 ** Math.max(1, len || 3);
+    const cap = Math.min(max, 1_000_000);
+    ns.print(`[DNET-CRACK] GuessNumber range [0, ${cap}]`);
+    // Binary search using feedback
+    let lo = 0, hi = cap;
+    const tried = new Set();
+    while (lo <= hi) {
+      const mid = Math.floor((lo + hi) / 2);
+      tried.add(String(mid));
+      const raw = await rdRaw(host, String(mid));
+      if (raw?.success) return { success: true, password: String(mid), model };
+      const fb = String(raw?.message ?? "").toLowerCase();
+      if (fb.includes("higher")) lo = mid + 1;
+      else if (fb.includes("lower")) hi = mid - 1;
+      else break; // fallback: linear scan
+      await ns.sleep(0);
+    }
+    // Linear sweep for any remaining numbers
+    for (let n = 0; n < cap; n++) {
+      if (tried.has(String(n))) continue;
+      const r = await tryPw(host, String(n), model, "linear");
+      if (r.success) return r;
+      if (n % 250 === 0) await ns.sleep(0);
+    }
+    return { success: false };
+  }
+
+  // 110100100 — BinaryEncodedFeedback: 8-bit groups in data decode to ASCII
+  async function crackBinary(host, model, len, hint, data) {
+    const chunks = [...String(data || hint).matchAll(/\b[01]{8}\b/g)].map(m => m[0]);
+    if (!chunks.length) return { success: false };
+    const pw = chunks.map(b => String.fromCharCode(parseInt(b, 2))).join("");
+    return tryCandidates(host, [pw], model, len, "binary decode");
+  }
+
+  // OrdoXenos — encryptedPassword: XOR each char against bitmask list
+  async function crackXor(host, model, len, hint, data) {
+    let payload = data;
+    if (!payload) {
+      const m = hint.match(/"([\s\S]*)".*?([01]{8}(?:\s+[01]{8})*)/);
+      if (m) payload = `${m[1]};${m[2]}`;
+    }
+    const [encoded, masksRaw] = String(payload).split(";");
+    if (!encoded || !masksRaw) return { success: false };
+    const masks = masksRaw.trim().split(/\s+/).map(b => parseInt(b, 2)).filter(Number.isFinite);
+    const pw = [...encoded].slice(0, masks.length)
+      .map((ch, i) => String.fromCharCode(ch.charCodeAt(0) ^ masks[i])).join("");
+    return tryCandidates(host, [pw], model, len, "xor decode");
+  }
+
+  // OctantVoxel — ConvertToBase10: decimal encoded in base N
+  async function crackBase10(host, model, hint, data) {
+    const parsed = parseBaseData(data) ?? parseBaseData(hint);
+    if (!parsed) return { success: false };
+    const [base, encoded] = parsed;
+    const value = parseBaseN(encoded, base);
+    if (!Number.isFinite(value)) return { success: false };
+    const candidates = [Math.round(value), Math.floor(value), Math.ceil(value)].map(String);
+    return tryCandidates(host, candidates, model, undefined, `base ${base} decode`);
+  }
+
+  // MathML — parsedExpression: evaluate arithmetic expression
+  // WARNING: source can embed "ns.exit()," injection — cleanArithmetic strips it
+  async function crackMath(host, model, hint, data) {
+    const expr = data || hint.replace(/^.*?expression\b/i, "");
+    const value = parseSimpleArithmetic(cleanArithmetic(expr));
+    if (!Number.isFinite(value)) return { success: false };
+    const candidates = [String(value), String(Math.round(value)),
+      String(Math.floor(value)), String(Math.ceil(value))];
+    return tryCandidates(host, candidates, model, undefined, "math eval");
+  }
+
+  // Pr0verFl0 — BufferOverflow: source-confirmed exploit
+  // buffer = "ˍ".repeat(passLen) + "■".repeat(passLen)
+  // overwritten = attempt + buffer.slice(attempt.length)
+  // success: overwritten.slice(0,passLen) === overwritten.slice(passLen)
+  // → sending "A".repeat(passLen*2) makes both halves identical → SUCCESS
+  async function crackBufferOverflow(host, model, len, hint) {
+    const bufferSize = Number((hint.match(/buffer\s+(?:is\s+)?(\d+)\s*(?:bytes)?/i) ?? [])[1])
+      || Number(len) || 4;
+    const payloadLen = bufferSize * 2;
+    ns.print(`[DNET-CRACK] Pr0verFl0 bufferSize=${bufferSize} payloadLen=${payloadLen}`);
+    // Primary: repeat any single char to fill both halves identically
+    const payloads = [
+      "A".repeat(payloadLen), "a".repeat(payloadLen),
+      "0".repeat(payloadLen), "x".repeat(payloadLen),
+      "A".repeat(bufferSize + 1), "0".repeat(bufferSize + 1),
+    ];
+    return tryCandidates(host, payloads, model, undefined, "buffer overflow");
+  }
+
+  // 2G_cellular — TimingAttack: each correct prefix char adds 50ms to response time
+  // Timing measured INSIDE the temp script to avoid exec overhead variance
+  async function crackTimingAttack(host, model, len, fmt) {
+    const n = len || 6;
+    if (n > 12) { ns.print(`[DNET-CRACK] 2G_cellular len=${n} too large`); return { success: false }; }
+    const charset = getCharset(fmt || (n > 6 ? "alphanumeric" : "numeric"), true);
+    let prefix = "";
+    ns.print(`[DNET-CRACK] 2G_cellular timing len=${n} charset=${charset.length}`);
+
+    // Each position: probe all chars inside a single temp script (eliminates exec overhead)
+    for (let pos = 0; pos < n; pos++) {
+      const timingExpr = `(async()=>{
+  const host=args[0]; const prefix=args[1]; const charset=[...args[2]]; const n=args[3]; const fillChar=charset[0];
+  let best={ch:charset[0],ms:-1};
+  for(const ch of charset){
+    const guess=(prefix+ch).padEnd(n,fillChar);
+    const t0=Date.now();
+    const r=await ns.dnet.authenticate(host,guess);
+    const ms=Date.now()-t0;
+    if(r?.success) return{success:true,pw:guess};
+    if(ms>best.ms) best={ch,ms};
+  }
+  return{success:false,bestChar:best.ch,bestMs:best.ms};
+})()`;
+      const r = await rd("timing", timingExpr, [host, prefix, charset, n], RD_TIMEOUT_MS * 5);
+      if (!r) { ns.print(`[DNET-CRACK] 2G timing probe failed at pos ${pos}`); return { success: false }; }
+      if (r.success) return { success: true, password: r.pw, model };
+      prefix += r.bestChar;
+      ns.print(`[DNET-CRACK] 2G_cellular prefix="${prefix}" (${r.bestMs?.toFixed(0)}ms at pos ${pos})`);
+    }
+    return tryPw(host, prefix, model, "2G timing final");
+  }
+
+  // DeepGreen — MastermindHint: filter pool by exact/misplaced counts per attempt
+  async function crackDeepGreen(host, model, len, fmt) {
+    const n = len || 3;
+    const charset = getCharset(fmt || "numeric", false);
+    const maxPool = 100_000;
+    let pool = generateCandidates(charset, n, fmt || "numeric");
+    if (!pool.length || pool.length > maxPool) {
+      ns.print(`[DNET-CRACK] DeepGreen pool too large len=${n} fmt=${fmt} count=${pool.length}`);
+      return { success: false };
+    }
+    const tried = new Set();
+    ns.print(`[DNET-CRACK] DeepGreen len=${n} fmt=${fmt} pool=${pool.length}`);
+
+    // Warm up with probe patterns
+    for (const ch of [...charset].slice(0, Math.min(charset.length, 10))) {
+      if (pool.length <= 1) break;
+      const guess = ch.repeat(n);
+      if (tried.has(guess)) continue;
+      const { r, fb } = await deepGreenAttempt(host, guess, model);
+      tried.add(guess);
+      if (r?.success) return { success: true, password: guess, model };
+      if (fb) {
+        pool = pool.filter(c => sameMastermind(c, guess, fb));
+        ns.print(`[DNET-CRACK] DG ${guess} → ${fb.exact},${fb.misplaced}; pool=${pool.length}`);
+      }
+      if (pool.length === 1 && !tried.has(pool[0])) break;
+      await ns.sleep(0);
+    }
+
+    while (pool.length) {
+      const guess = pool.find(c => !tried.has(c));
+      if (!guess) break;
+      const { r, fb } = await deepGreenAttempt(host, guess, model);
+      tried.add(guess);
+      if (r?.success) return { success: true, password: guess, model };
+      if (!fb) return { success: false };
+      pool = pool.filter(c => sameMastermind(c, guess, fb));
+      ns.print(`[DNET-CRACK] DG ${guess} → ${fb.exact},${fb.misplaced}; pool=${pool.length}`);
+      if (pool.length === 1 && !tried.has(pool[0])) {
+        return tryPw(host, pool[0], model, "DeepGreen final");
+      }
+      if (tried.size % 25 === 0) await ns.sleep(0);
+    }
+    return { success: false };
+  }
+
+  async function deepGreenAttempt(host, guess, model) {
+    const raw = await rdRaw(host, guess);
+    if (raw?.success) return { r: raw, fb: null };
+    const fb = parseDeepGreenFeedback(raw);
+    return { r: raw, fb };
+  }
+
+  // NIL — Yesn't: per-position yes/yesn't feedback; elimination matrix
+  async function crackNil(host, model, len, fmt) {
+    const n = len || 4;
+    const chars = [...getCharset(fmt || "numeric", true)];
+    const pos = Array.from({ length: n }, () => new Set(chars));
+    const tried = new Set();
+    const obs = [];
+
+    const known = () => pos.map(s => s.size === 1 ? [...s][0] : null);
+    const solved = () => pos.every(s => s.size === 1);
+
+    ns.print(`[DNET-CRACK] NIL len=${n} fmt=${fmt} charset=${chars.length}`);
+
+    // Phase 1: probe each char across all positions
+    for (const ch of chars) {
+      if (solved()) break;
+      const k = known();
+      const guess = k.map((v, i) => v ?? (pos[i].has(ch) ? ch : [...pos[i]][0])).join("");
+      if (tried.has(guess)) { await ns.sleep(0); continue; }
+
+      const raw = await rdRaw(host, guess);
+      tried.add(guess);
+      if (raw?.success) return { success: true, password: guess, model };
+
+      const mask = parseNilMask(raw, n);
+      if (!mask) { await ns.sleep(0); continue; }
+      obs.push({ guess, mask });
+
+      for (let i = 0; i < n; i++) {
+        if (mask[i] === "yes") { pos[i] = new Set([guess[i]]); }
+        else { pos[i].delete(guess[i]); }
+      }
+      ns.print(`[DNET-CRACK] NIL ${guess} → ${mask.join(",")} | ${known().map(v => v ?? "_").join("")}`);
+      await ns.sleep(0);
+    }
+
+    if (solved()) {
+      const final = known().join("");
+      if (!tried.has(final)) return tryPw(host, final, model, "NIL solved");
+      return { success: false };
+    }
+
+    // Phase 2: constraint search for residual unknowns
+    const unknownIdx = known().reduce((a, v, i) => (v === null && a.push(i), a), []);
+    const kArr = known();
+    const fill = combo => kArr.map((v, i) => {
+      const ui = unknownIdx.indexOf(i);
+      return ui >= 0 ? combo[ui] : v;
+    }).join("");
+
+    let pool = cartesianProduct(unknownIdx.map(i => [...pos[i]]))
+      .filter(c => obs.every(o => matchesYesnt(fill(c), o.guess, o.mask)));
+
+    ns.print(`[DNET-CRACK] NIL phase-2 unknowns=${unknownIdx.length} pool=${pool.length}`);
+    if (pool.length > 100_000) return { success: false };
+
+    while (pool.length) {
+      const combo = pool.find(c => !tried.has(fill(c)));
+      if (!combo) break;
+      const guess = fill(combo);
+      const raw = await rdRaw(host, guess);
+      tried.add(guess);
+      if (raw?.success) return { success: true, password: guess, model };
+      const mask = parseNilMask(raw, n);
+      if (!mask) break;
+      pool = pool.filter(c => matchesYesnt(fill(c), guess, mask));
+      if (pool.length === 1 && !tried.has(fill(pool[0])))
+        return tryPw(host, fill(pool[0]), model, "NIL p2 final");
+      if (tried.size % 25 === 0) await ns.sleep(0);
+    }
+    return { success: false };
+  }
+
+  // Factori-Os — divisibilityTest: password is product of primes, brute respecting length
+  async function crackDivisibility(host, model, len) {
+    const passLen = Number(len || 0);
+    const start = passLen > 1 ? 10 ** (passLen - 1) : 0;
+    const end   = passLen > 0 ? 10 ** passLen : 100_000;
+    if (end - start > 1_000_000) {
+      ns.print(`[DNET-CRACK] Factori-Os range too large: [${start},${end - 1}]`);
+      return { success: false };
+    }
+    ns.print(`[DNET-CRACK] Factori-Os brute [${start},${end - 1}]`);
+    for (let n = start; n < end; n++) {
+      const pw = String(n);
+      if (passLen > 0 && pw.length !== passLen) continue;
+      const r = await tryPw(host, pw, model, "numeric brute");
+      if (r.success) return r;
+      if ((n - start) % 250 === 0) await ns.sleep(0);
+    }
+    return { success: false };
+  }
+
+  // BigMo%od — tripleModulo: source-confirmed formula (P%n)%((n-1)%32+1)=r
+  // FIXED from existing script which used wrong formula c.n%32 instead of ((c.n-1)%32)+1
+  async function crackBigMo(host, model, len) {
+    const passLen = Number(len || 0);
+    const lo = passLen > 1 ? 10 ** (passLen - 1) : 0;
+    const hi = passLen > 0 ? 10 ** passLen - 1 : 999_999;
+    const maxTry = 20_000;
+    const constraints = [];
+    const triedProbes = new Set();
+
+    function addConstraint(c) {
+      if (!c || !Number.isFinite(c.n) || !Number.isFinite(c.r)) return;
+      if (c.n <= 1) return;
+      const m = ((c.n - 1) % 32) + 1; // source-exact formula
+      if (m <= 1) return;
+      if (constraints.some(x => x.n === c.n)) return;
+      constraints.push({ n: c.n, m, r: c.r });
+      ns.print(`[DNET-CRACK] BigMo constraint ${c.n}: (P%${c.n})%${m}=${c.r}`);
+    }
+
+    async function probe(n) {
+      if (triedProbes.has(n)) return null;
+      triedProbes.add(n);
+      const raw = await rdRaw(host, String(n));
+      if (raw?.success) return { done: true, password: String(n) };
+      addConstraint(parseBigMoResponse(raw, n));
+      return null;
+    }
+
+    ns.print(`[DNET-CRACK] BigMo len=${passLen || "?"} range=[${lo},${hi}]`);
+
+    // Seed from heartbleed logs
+    const hb = await rdHeartbleed(host);
+    for (const c of parseBigMoHeartbleed(hb.logs ?? [])) addConstraint(c);
+
+    // Probe plan: values where (n-1)%32 > 1 (gives useful modulus)
+    const probePlan = [257,259,261,263,265,269,271,277,281,283,293,307,311,313,317,331,337,347,349,353,359,367,373,379,383,389,397,401,409,419,421,431,433,439,443,449,457,461,463,467,479,487,491,499]
+      .filter(n => ((n - 1) % 32) + 1 > 1);
+
+    for (const n of probePlan) {
+      const r = await probe(n);
+      if (r?.done) return { success: true, password: r.password, model };
+      if (constraints.length >= 6) break;
+      await ns.sleep(0);
+    }
+
+    if (hi - lo + 1 > 12_000_000) {
+      ns.print(`[DNET-CRACK] BigMo range too large for scan`);
+      return { success: false };
+    }
+
+    let candidates = collectBigMoCandidates(lo, hi, passLen, constraints, maxTry + 1);
+    ns.print(`[DNET-CRACK] BigMo candidates after ${constraints.length} constraints: ${candidates.length}${candidates.length > maxTry ? "+" : ""}`);
+
+    for (const n of probePlan) {
+      if (candidates.length <= maxTry) break;
+      const r = await probe(n);
+      if (r?.done) return { success: true, password: r.password, model };
+      candidates = collectBigMoCandidates(lo, hi, passLen, constraints, maxTry + 1);
+      ns.print(`[DNET-CRACK] BigMo narrowed to ${candidates.length}`);
+      await ns.sleep(0);
+    }
+
+    if (!candidates.length || candidates.length > maxTry) return { success: false };
+    return tryCandidates(host, candidates, model, passLen || undefined, "BigMo constrained");
+  }
+
+  // OpenWebAccessPoint — packetSniffer: heartbleed logs contain "Logging in with passcode: PW"
+  async function crackOpenWeb(host, model, len, fmt, hint, data) {
+    const n = Number(len || 0);
+    const hb = await rdHeartbleed(host);
+    const logLines = hb.logs ?? [];
+    const allText = [hint, data, ...logLines].join("\n");
+
+    const priority = [];
+    for (const m of allText.matchAll(/Logging in with passcode:\s*(\S+?)(?:\s|\.{3}|$)/gi))
+      priority.push(m[1]);
+    const hostRe = new RegExp(host.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + ":([\\w]+)", "g");
+    for (const m of allText.matchAll(hostRe)) priority.push(m[1]);
+
+    const clean = [...new Set(priority)].filter(p => !n || p.length === n);
+    if (clean.length) {
+      const r = await tryCandidates(host, clean, model, undefined, "heartbleed direct");
+      if (r.success) return r;
+    }
+
+    const nums = [...new Set(extractNumbers(allText))].filter(p => !n || p.length === n);
+    if (nums.length) {
+      const r = await tryCandidates(host, nums, model, undefined, "text numbers");
+      if (r.success) return r;
+    }
+
+    const staticCandidates = ["", ...DEFAULTS, ...DOGS, ...hostDerivedCandidates(host, n)];
+    return tryCandidates(host, staticCandidates, model, undefined, "static/derived");
+  }
+
+  // KingOfTheHill — globalMaxima: Gaussian altitude; ternary search or gradient ascent (SF15 only)
+  // f(x) = 10000 * exp(-k * (x-password)^2), success when altitude = 10000
+  async function crackKingOfTheHill(host, model, len) {
+    const n = len || 2;
+    const lo = n > 1 ? 10 ** (n - 1) : 0;
+    const hi = 10 ** n - 1;
+    const tried = new Set();
+    const altCache = new Map();
+
+    function altitude(raw) {
+      if (!raw) return 0;
+      if (raw.success) return Infinity;
+      const v = Number(raw.data);
+      if (Number.isFinite(v) && v >= 0) return v;
+      const m = String(raw.message ?? "").match(/altitude.*?([\d.]+)/i);
+      return m ? Number(m[1]) : 0;
+    }
+
+    async function sampleAlt(g) {
+      const pw = String(g);
+      if (altCache.has(pw)) return altCache.get(pw);
+      tried.add(pw);
+      const raw = await rdRaw(host, pw);
+      const alt = altitude(raw);
+      altCache.set(pw, { alt, success: !!raw?.success });
+      return altCache.get(pw);
+    }
+
+    async function tryKotH(pw) {
+      if (!pw || pw.length !== n || (n > 1 && pw.startsWith("0")) || tried.has(pw)) return null;
+      return tryPw(host, pw, model, "KotH");
+    }
+
+    ns.print(`[DNET-CRACK] KotH len=${n} range=[${lo},${hi}]`);
+
+    // Heartbleed: extract previous altitude attempts and focus near best
+    const hb = await rdHeartbleed(host);
+    const records = parseKotHHeartbleed(hb.logs ?? [], n)
+      .filter(r => r.attempt >= lo && r.attempt <= hi)
+      .sort((a, b) => b.alt - a.alt);
+
+    if (records.length) {
+      const priority = [];
+      for (const rec of records.slice(0, 8)) {
+        priority.push(rec.password);
+        priority.push(...neighborStrings(rec.attempt, n, lo, hi, 3));
+        if (n <= 6) priority.push(...uniquePermutationsArray(rec.password, 720));
+      }
+      for (const pw of uniqueStrings(priority)) {
+        const r = await tryKotH(pw);
+        if (r?.success) return r;
+      }
+    }
+
+    // Ternary search
+    const t1 = Math.floor(lo + (hi - lo) / 3);
+    const t2 = Math.floor(hi - (hi - lo) / 3);
+    const p1 = await sampleAlt(t1);
+    const p2 = await sampleAlt(t2);
+    if (p1?.success) return { success: true, password: String(t1), model };
+    if (p2?.success) return { success: true, password: String(t2), model };
+
+    if (p1?.alt > 0 || p2?.alt > 0) {
+      // Wide Gaussian — ternary search
+      let [tlo, thi] = [lo, hi];
+      while (thi - tlo > 4) {
+        const m1 = Math.floor(tlo + (thi - tlo) / 3);
+        const m2 = Math.floor(thi - (thi - tlo) / 3);
+        const s1 = await sampleAlt(m1); if (s1?.success) return { success: true, password: String(m1), model };
+        const s2 = await sampleAlt(m2); if (s2?.success) return { success: true, password: String(m2), model };
+        ns.print(`[DNET-CRACK] KotH ternary [${tlo},${thi}] ${m1}→${s1?.alt.toFixed(0)} ${m2}→${s2?.alt.toFixed(0)}`);
+        if (s1?.alt >= s2?.alt) thi = m2; else tlo = m1;
+        await ns.sleep(0);
+      }
+      for (let g = tlo - 2; g <= thi + 2; g++) {
+        const r = await tryKotH(String(g));
+        if (r?.success) return r;
+      }
+    } else {
+      // Narrow Gaussian — step scan + gradient ascent
+      let best = lo, bestAlt = 0;
+      for (let g = lo; g <= hi; g += 3) {
+        const p = await sampleAlt(g);
+        if (p?.success) return { success: true, password: String(g), model };
+        if (p?.alt > bestAlt) { bestAlt = p.alt; best = g; }
+        if (p?.alt > 50) break;
+        if (tried.size % 100 === 0) await ns.sleep(0);
+      }
+      if (!bestAlt) {
+        for (let g = hi; g >= lo; g -= 3) {
+          const p = await sampleAlt(g);
+          if (p?.success) return { success: true, password: String(g), model };
+          if (p?.alt > bestAlt) { bestAlt = p.alt; best = g; }
+          if (p?.alt > 50) break;
+          if (tried.size % 100 === 0) await ns.sleep(0);
+        }
+      }
+      if (!bestAlt) return { success: false };
+      let cur = best, curAlt = bestAlt;
+      ns.print(`[DNET-CRACK] KotH ascending from ${cur} (${curAlt.toFixed(0)}m)`);
+      while (true) {
+        let nextBest = null;
+        for (const delta of [1, -1]) {
+          const next = cur + delta;
+          if (next < lo || next > hi) continue;
+          const p = await sampleAlt(next);
+          if (p?.success) return { success: true, password: String(next), model };
+          if (p?.alt > curAlt && (!nextBest || p.alt > nextBest.alt)) nextBest = { v: next, alt: p.alt };
+        }
+        if (!nextBest) break;
+        cur = nextBest.v; curAlt = nextBest.alt;
+        await ns.sleep(0);
+      }
+      if (n <= 6) {
+        for (const pw of uniquePermutationsArray(String(cur), 720)) {
+          const r = await tryKotH(pw);
+          if (r?.success) return r;
+        }
+      }
+    }
+    return { success: false };
+  }
+
+  // RateMyPix.Auth — SpiceLevel: 🌶️/len score; each pos: swap chars until score drops
+  async function crackRateMyPix(host, model, len, fmt, hint, data) {
+    const n = Number(len || 0);
+    if (!n || n > 64) return { success: false };
+    const charset = [...getCharset(fmt || "alphanumeric", true)];
+    const baseline = charset.includes("0") ? "0" : charset[0];
+    const baseGuess = baseline.repeat(n);
+
+    async function scoreAttempt(pw) {
+      const raw = await rdRaw(host, pw);
+      if (raw?.success) return { success: true };
+      const score = parseRateMyPixScore(raw, n);
+      return { success: false, score };
+    }
+
+    ns.print(`[DNET-CRACK] RateMyPix len=${n} fmt=${fmt} charset=${charset.length}`);
+    let base = await scoreAttempt(baseGuess);
+    if (base.success) return { success: true, password: baseGuess, model };
+    if (!Number.isFinite(base.score)) {
+      ns.print(`[DNET-CRACK] RateMyPix no parseable score from baseline`);
+      return { success: false };
+    }
+
+    const solved = Array(n).fill(null);
+    for (let i = 0; i < n; i++) {
+      for (const ch of charset) {
+        if (ch === baseline) continue;
+        const arr = baseGuess.split("");
+        arr[i] = ch;
+        const r = await scoreAttempt(arr.join(""));
+        if (r.success) return { success: true, password: arr.join(""), model };
+        if (!Number.isFinite(r.score)) continue;
+        if (r.score > base.score) { solved[i] = ch; break; }
+        if (r.score < base.score) { solved[i] = baseline; break; }
+        await ns.sleep(0);
+      }
+      if (!solved[i]) solved[i] = baseline;
+      ns.print(`[DNET-CRACK] RateMyPix pos ${i + 1}/${n}: ${solved[i]}`);
+    }
+
+    if (solved.every(Boolean)) {
+      return tryPw(host, solved.join(""), model, "RateMyPix score-solve");
+    }
+    return { success: false };
+  }
+
+  async function crackGeneric(host, model, len, hint, data) {
+    const candidates = [...extractNumbers(`${hint}\n${data}`), ...DEFAULTS, ...DOGS];
+    return tryCandidates(host, candidates, model, len, "generic");
+  }
+
+  // ── Feedback parsers ──────────────────────────────────────────────────────
+
+  function parseDeepGreenFeedback(raw) {
+    if (!raw) return null;
+    const text = `${raw.data ?? ""}\n${raw.message ?? ""}`;
+    const m = text.match(/(?:data["']?\s*[:=]\s*["']?)?(\d+)\s*,\s*(\d+)/i);
+    return m ? { exact: Number(m[1]), misplaced: Number(m[2]) } : null;
+  }
+
+  function parseNilMask(raw, n) {
+    if (!raw) return null;
+    const text = `${raw.data ?? ""}\n${raw.message ?? ""}`;
+    // "yesn't" must come before "yes" in alternation to avoid partial match
+    const m = text.match(/data["']?\s*[:=]\s*["']?((?:yesn't|yes)(?:\s*,\s*(?:yesn't|yes))*)/i);
+    if (!m) return null;
+    const parts = m[1].split(/\s*,\s*/).map(x => x.toLowerCase().trim());
+    return parts.length === n && parts.every(x => x === "yes" || x === "yesn't") ? parts : null;
+  }
+
+  function parseBellaFeedback(raw) {
+    const text = `${raw?.message ?? ""}\n${raw?.data ?? ""}`.toUpperCase();
+    if (text.includes("PARUM BREVIS") || text.includes("TOO LOW")) return "low";
+    if (text.includes("ALTUS NIMIS") || text.includes("TOO HIGH")) return "high";
+    return null;
+  }
+
+  // BigMo%od — source formula: (P%n)%((n-1)%32+1)=r
+  function parseBigMoResponse(raw, attempted) {
+    if (!raw) return null;
+    const text = `${raw.message ?? ""}\n${raw.data ?? ""}`;
+    // Extract result r from "= R" at end of the feedback expression
+    const eqMatch = text.match(/=\s*(-?\d+)\s*$/m) || text.match(/\)\s*=\s*(-?\d+)/);
+    const n = Number(attempted);
+    const r = eqMatch ? Number(eqMatch[1]) : NaN;
+    if (!Number.isFinite(n) || n <= 1 || !Number.isFinite(r)) return null;
+    return { n, r };
+  }
+
+  function parseBigMoHeartbleed(logs) {
+    const text = (logs ?? []).map(x => typeof x === "string" ? x : JSON.stringify(x)).join("\n");
+    const out = [];
+    // Match the formula structure and extract n and r
+    const re = /Password\s*%\s*(\d+)[^=]*=\s*(-?\d+)/gi;
+    for (const m of text.matchAll(re)) {
+      const n = Number(m[1]);
+      const r = Number(m[2]);
+      if (Number.isFinite(n) && Number.isFinite(r) && n > 1) out.push({ n, r });
+    }
+    return out;
+  }
+
+  function parseRateMyPixScore(raw, len = 0) {
+    const text = `${raw?.data ?? ""}\n${raw?.message ?? ""}`;
+    const slash = text.match(/([0-9]+)\s*\/\s*([0-9]+)/);
+    if (slash) return Number(slash[1]);
+    const peppers = [...text.matchAll(/🌶(?:️)?/gu)].length;
+    return peppers || null;
+  }
+
+  function parseKotHHeartbleed(logs, len) {
+    const text = (logs ?? []).map(x => typeof x === "string" ? x : JSON.stringify(x)).join("\n");
+    const out = [];
+    const re = /current altitude:\s*([\d.]+)\s*m[\s\S]*?passwordAttempted:\s*([^\s\n]+)/gi;
+    for (const m of text.matchAll(re)) {
+      const alt = Number(m[1]);
+      const pw = String(m[2] ?? "").trim();
+      if (!Number.isFinite(alt) || !/^\d+$/.test(pw)) continue;
+      if (len && pw.length !== len) continue;
+      out.push({ alt, password: pw, attempt: Number(pw) });
+    }
+    return out;
+  }
+
+  // ── Ledger / spreading ────────────────────────────────────────────────────
+
+  function readLedger() {
+    const out = new Map();
+    try {
+      const raw = String(ns.read(LEDGER) || "");
+      for (const line of raw.split(/\r?\n/)) {
+        if (!line.trim()) continue;
+        const [host, pw = "", model = "?"] = line.split("|");
+        if (host) out.set(host, { password: pw, model });
+      }
+    } catch (_) {}
+    return out;
+  }
+
+  async function writeLedger(map) {
+    const rows = [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([h, r]) => `${h}|${r.password ?? ""}|${r.model ?? "?"}`);
+    try { await ns.write(LEDGER, rows.join("\n") + (rows.length ? "\n" : ""), "w"); } catch (_) {}
+  }
+
+  async function recordPassword(host, password, model) {
+    const map = readLedger();
+    const old = map.get(host);
+    if (old && old.password === String(password ?? "") && old.model === model) return;
+    map.set(host, { password: String(password ?? ""), model });
+    await writeLedger(map);
+    ns.print(`[DNET-CRACK] saved ${host} model=${model}`);
+  }
+
+  async function pullLedgerFromHome() {
+    try { if (ns.fileExists(LEDGER, HOME)) await ns.scp(LEDGER, HOST, HOME); }
+    catch (e) { ns.print(`[DNET-CRACK] ledger pull failed: ${e}`); }
+  }
+
+  async function pushLedgerToHome() {
+    try { if (ns.fileExists(LEDGER, HOST)) await ns.scp(LEDGER, HOME, HOST); }
+    catch (e) { ns.print(`[DNET-CRACK] ledger push failed: ${e}`); }
+  }
+
+  async function spread(host, password) {
+    try { await rdConnect(host, password); } catch (_) {}
+
+    const files = [CRAWL, CRACK, OPS, SCRAPE, ROUTE, LAB, LEDGER, MAP]
+      .filter(f => ns.fileExists(f, HOST));
+    try { await ns.scp(files, host, HOST); }
+    catch (e) { ns.print(`[DNET-CRACK] scp to ${host} failed: ${e}`); return; }
+
+    const extraArgs = [
+      ...(ENABLE_SCRAPE ? ["--scrape"] : []),
+      ...(COPY_HOME ? ["--copy-home"] : []),
+    ];
+    const pid = ns.exec(CRAWL, host, { preventDuplicates: true }, ...extraArgs);
+    ns.print(`[DNET-CRACK] spread ${CRAWL} → ${host} pid=${pid}`);
+    if (pid > 0) {
+      ns.exec(OPS, host, { preventDuplicates: true }, "--realloc");
+    }
+  }
+
+  async function dumpUnknown(host, details, logs) {
+    const block = [
+      `=== ${new Date().toISOString()} ${host} ===`,
+      `modelId: ${details.modelId}`,
+      `passwordLength: ${details.passwordLength ?? "?"}`,
+      `passwordFormat: ${details.passwordFormat ?? ""}`,
+      `passwordHint: ${details.passwordHint ?? ""}`,
+      `data: ${details.data ?? details.passwordHintData ?? ""}`,
+      `--- logs ---`,
+      ...logs,
+      "",
+    ].join("\n");
+    try { await ns.write(UNKNOWN, block, "a"); }
+    catch (_) {}
+    ns.print(`[DNET-CRACK] unsolved ${host} model=${details.modelId}; appended to ${UNKNOWN}`);
+  }
+
+  // ── Lock helpers ──────────────────────────────────────────────────────────
+
+  function acquireTargetLock() {
+    const now = Date.now();
+    try {
+      if (ns.fileExists(LOCK, HOST)) {
+        const ts = Number(String(ns.read(LOCK) || "").split("|")[0]);
+        if (Number.isFinite(ts) && now - ts < LOCK_TTL_MS) return false;
+      }
+      ns.write(LOCK, `${now}|${target}|${HOST}`, "w");
+      return true;
+    } catch (_) { return true; }
+  }
+
+  function releaseTargetLock() {
+    try {
+      const raw = String(ns.read(LOCK) || "");
+      if (!raw || raw.includes(`|${target}|`)) ns.rm(LOCK, HOST);
+    } catch (_) {}
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════════════════
+// Module-level constants (source-exact from bitburner-src dictionaryData.ts)
+// ════════════════════════════════════════════════════════════════════════════════
+
+const DEFAULTS = ["admin", "password", "0000", "12345"]; // FreshInstall_1.0
+const DOGS     = ["fido", "spot", "rover", "max"];        // Laika4
+
+// EuroZone Free — CRITICAL: exact names from source (NOT "Cyprus"/"Czechia"/"The Netherlands")
+const EU_COUNTRIES = [
+  "Austria", "Belgium", "Bulgaria", "Croatia", "Republic of Cyprus", "Czech Republic",
+  "Denmark", "Estonia", "Finland", "France", "Germany", "Greece", "Hungary", "Ireland",
+  "Italy", "Latvia", "Lithuania", "Luxembourg", "Malta", "Netherlands", "Poland",
+  "Portugal", "Romania", "Slovakia", "Slovenia", "Spain", "Sweden",
+];
+
+const COMMON_PASSWORDS = [
+  "123456","password","12345678","qwerty","123456789","12345","1234","111111","1234567",
+  "dragon","123123","baseball","abc123","football","monkey","letmein","696969","shadow",
+  "master","666666","qwertyuiop","123321","mustang","1234567890","michael","654321",
+  "superman","1qaz2wsx","7777777","121212","0","qazwsx","123qwe","trustno1","jordan",
+  "jennifer","zxcvbnm","asdfgh","hunter","buster","soccer","harley","batman","andrew",
+  "tigger","sunshine","iloveyou","2000","charlie","robert","thomas","hockey","ranger",
+  "daniel","starwars","112233","george","computer","michelle","jessica","pepper","1111",
+  "zxcvbn","555555","11111111","131313","freedom","777777","pass","maggie","159753",
+  "aaaaaa","ginger","princess","joshua","cheese","amanda","summer","love","ashley",
+  "6969","nicole","chelsea","biteme","matthew","access","yankees","987654321","dallas",
+  "austin","thunder","taylor","matrix",
+];
+
+// ════════════════════════════════════════════════════════════════════════════════
+// Pure JS helpers (no ns.* calls — zero additional RAM cost)
+// ════════════════════════════════════════════════════════════════════════════════
+
+const NUMBERS = "0123456789";
+const LETTERS = "abcdefghijklmnopqrstuvwxyz";
+const LETTERS_UP = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const ALPHANUM = NUMBERS + LETTERS + LETTERS_UP;
+
+function getCharset(fmt = "", includeUpper = false) {
+  const f = String(fmt || "").toLowerCase();
+  if (f === "numeric")      return NUMBERS;
+  if (f === "alphabetic")   return includeUpper ? LETTERS + LETTERS_UP : LETTERS;
+  if (f === "alphanumeric") return includeUpper ? NUMBERS + LETTERS + LETTERS_UP : NUMBERS + LETTERS;
+  return includeUpper ? ALPHANUM : NUMBERS + LETTERS;
+}
+
+function generateCandidates(charset, n, fmt = "") {
+  const f = String(fmt || "").toLowerCase();
+  const chars = [...charset];
+  const noLeadZero = f === "numeric" && n > 1;
+  const out = [];
+  function rec(prefix) {
+    if (prefix.length === n) { out.push(prefix); return; }
+    for (const ch of chars) {
+      if (prefix.length === 0 && noLeadZero && ch === "0") continue;
+      rec(prefix + ch);
+      if (out.length > 100_000) return;
+    }
+  }
+  rec(""); return out;
+}
+
+function cleanCandidates(arr, len) {
+  return [...new Set(
+    arr.flat().filter(x => x !== null && x !== undefined)
+      .map(String).filter(x => x.length > 0 || len === 0)
+      .filter(x => !len || x.length === len || x === "")
+  )];
+}
+
+function countryVariants(country) {
+  const raw = String(country ?? "").trim();
+  const lower = raw.toLowerCase();
+  const title = raw.split(/\s+/).map(w => w ? w[0].toUpperCase() + w.slice(1).toLowerCase() : w).join(" ");
+  const noThe = lower.replace(/^the\s+/, "");
+  return uniqueStrings([raw, lower, title, noThe, lower.replace(/\s+/g, "")]);
+}
+
+function extractNumbers(str) {
+  return [...String(str).matchAll(/\b(\d+)\b/g)].map(m => m[1]);
+}
+
+function digitsOnly(str, len = 0) {
+  const d = String(str).replace(/[^0-9]/g, "");
+  if (!len) return d || null;
+  return d.length >= len ? d.slice(0, len) : null;
+}
+
+function extractRomanTokens(str) {
+  return [...String(str).matchAll(/\b([IVXLCDM]+|nulla)\b/gi)].map(m => m[1]);
+}
+
+function romanToInt(input) {
+  if (!input) return null;
+  if (String(input).toLowerCase() === "nulla") return 0;
+  const roman = String(input).toUpperCase();
+  const v = { I:1, V:5, X:10, L:50, C:100, D:500, M:1000 };
+  let total = 0, prev = 0;
+  for (let i = roman.length - 1; i >= 0; i--) {
+    const cur = v[roman[i]]; if (!cur) return null;
+    total += cur < prev ? -cur : cur; prev = cur;
+  }
+  return total;
+}
+
+function parseRomanRange(str) {
+  const vals = extractRomanTokens(str).map(romanToInt).filter(x => x !== null);
+  return vals.length >= 2 ? [vals[0], vals[1]] : null;
+}
+
+function largestPrimeFactor(n) {
+  n = Math.floor(Number(n));
+  if (!Number.isFinite(n) || n < 2) return null;
+  let largest = 1;
+  while (n % 2 === 0) { largest = 2; n /= 2; }
+  for (let f = 3; f * f <= n; f += 2) { while (n % f === 0) { largest = f; n /= f; } }
+  return n > 1 ? n : largest;
+}
+
+function parseBaseData(str) {
+  const s = String(str);
+  const direct = s.match(/^\s*([0-9]+)\s*,\s*([0-9A-Z.]+)\s*$/i);
+  if (direct) return [Number(direct[1]), direct[2].toUpperCase()];
+  const hint = s.match(/base\s+([0-9]+)\s+(?:number\s+)?([0-9A-Z.]+)/i);
+  if (hint) return [Number(hint[1]), hint[2].toUpperCase()];
+  return null;
+}
+
+function parseBaseN(numberString, base) {
+  const chars = [...NUMBERS, ..."ABCDEFGHIJKLMNOPQRSTUVWXYZ"];
+  const s = String(numberString).toUpperCase();
+  let result = 0, index = 0;
+  let digit = s.split(".")[0].length - 1;
+  while (index < s.length) {
+    const ch = s[index];
+    if (ch === ".") { index++; continue; }
+    const place = chars.indexOf(ch);
+    if (place < 0) return NaN;
+    result += place * base ** digit;
+    index++; digit--;
+  }
+  return result;
+}
+
+function cleanArithmetic(expr) {
+  return String(expr)
+    .replaceAll("ҳ", "*").replaceAll("÷", "/").replaceAll("➕", "+").replaceAll("➖", "-")
+    .replaceAll("ns.exit(),", "").split(",")[0]
+    .replace(/[^0-9+\-*/().\s]/g, "");
+}
+
+function parseSimpleArithmetic(expression) {
+  const tokens = cleanArithmetic(expression).replace(/\s+/g, "").split("");
+  let depth = 0;
+  const depths = tokens.map(t => { if (t === "(") depth++; else if (t === ")") { depth--; return depth + 1; } return depth; });
+  const d1 = depths.indexOf(1);
+  if (d1 !== -1) {
+    let end = depths.indexOf(0, d1);
+    if (end === -1) end = depths.length - 1;
+    const sub = parseSimpleArithmetic(tokens.slice(d1 + 1, end).join(""));
+    tokens.splice(d1, end - d1 + 1, sub.toString());
+    return parseSimpleArithmetic(tokens.join(""));
+  }
+  let rem = tokens.join("");
+  let m = rem.match(/(-?\d*\.?\d+) *([*/]) *(-?\d*\.?\d+)/);
+  while (m) {
+    const res = m[2] === "*" ? parseFloat(m[1]) * parseFloat(m[3]) : parseFloat(m[1]) / parseFloat(m[3]);
+    rem = rem.replace(m[0], res.toString());
+    m = rem.match(/(-?\d*\.?\d+) *([*/]) *(-?\d*\.?\d+)/);
+  }
+  m = rem.match(/(-?\d*\.?\d+) *([+-]) *(-?\d*\.?\d+)/);
+  while (m) {
+    const res = m[2] === "+" ? parseFloat(m[1]) + parseFloat(m[3]) : parseFloat(m[1]) - parseFloat(m[3]);
+    rem = rem.replace(m[0], res.toString());
+    m = rem.match(/(-?\d*\.?\d+) *([+-]) *(-?\d*\.?\d+)/);
+  }
+  return parseFloat((rem.match(/(-?\d*\.?\d+)/) ?? ["", ""])[1]);
+}
+
+function sameMastermind(candidate, guess, fb) {
+  let exact = 0;
+  const c = new Map(), g = new Map();
+  for (let i = 0; i < candidate.length; i++) {
+    if (candidate[i] === guess[i]) exact++;
+    else {
+      c.set(candidate[i], (c.get(candidate[i]) || 0) + 1);
+      g.set(guess[i], (g.get(guess[i]) || 0) + 1);
+    }
+  }
+  let mis = 0;
+  for (const [ch, n] of c) mis += Math.min(n, g.get(ch) || 0);
+  return exact === fb.exact && mis === fb.misplaced;
+}
+
+function matchesYesnt(candidate, guess, mask) {
+  for (let i = 0; i < mask.length; i++) {
+    if (mask[i] === "yes" && candidate[i] !== guess[i]) return false;
+    if (mask[i] === "yesn't" && candidate[i] === guess[i]) return false;
+  }
+  return true;
+}
+
+function cartesianProduct(arrays) {
+  return arrays.reduce((acc, arr) => acc.flatMap(combo => arr.map(v => [...combo, v])), [[]]);
+}
+
+function collectBigMoCandidates(lo, hi, len, constraints, limit = Infinity) {
+  const out = [];
+  if (!constraints.length) return out;
+  for (let p = lo; p <= hi; p++) {
+    const s = String(p);
+    if (len && s.length !== len) continue;
+    if (constraints.every(c => (p % c.n) % c.m === c.r)) out.push(s);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+function* uniquePermutations(str, max = Infinity) {
+  const counts = new Map();
+  for (const ch of str) counts.set(ch, (counts.get(ch) || 0) + 1);
+  const chars = [...counts.keys()].sort();
+  const buf = [];
+  let n = 0;
+  function* rec() {
+    if (n >= max) return;
+    if (buf.length === str.length) { n++; yield buf.join(""); return; }
+    for (const ch of chars) {
+      const left = counts.get(ch) || 0;
+      if (!left) continue;
+      counts.set(ch, left - 1); buf.push(ch);
+      yield* rec();
+      buf.pop(); counts.set(ch, left);
+      if (n >= max) return;
+    }
+  }
+  yield* rec();
+}
+
+function uniquePermutationsArray(str, max = Infinity) {
+  const out = [];
+  for (const p of uniquePermutations(String(str), max)) out.push(p);
+  return out;
+}
+
+function uniqueStrings(values) {
+  return [...new Set(values.map(v => String(v ?? "")).filter(v => v.length > 0))];
+}
+
+function neighborStrings(value, len, lo, hi, radius = 2) {
+  const out = [];
+  for (let n = Number(value) - radius; n <= Number(value) + radius; n++) {
+    if (!Number.isFinite(n) || n < lo || n > hi) continue;
+    const s = String(Math.trunc(n));
+    if (s.length === len) out.push(s);
+  }
+  return out;
+}
+
+function hostDerivedCandidates(host, len = 0) {
+  const raw = String(host || "");
+  const parts = raw.split(/[^0-9a-zA-Z]+/).filter(Boolean);
+  const out = [raw, raw.replace(/[^0-9a-zA-Z]/g, "")];
+  for (const p of parts) {
+    out.push(p, p.toLowerCase());
+    const digits = p.replace(/[^0-9]/g, "");
+    if (digits) out.push(digits);
+  }
+  return uniqueStrings(out);
+}
+
+function dirname(file) {
+  const idx = String(file).lastIndexOf("/");
+  return idx <= 0 ? "" : file.slice(0, idx);
+}
+
+function safeFileName(value) {
+  return String(value).replace(/[^a-zA-Z0-9_.-]/g, "_").slice(0, 80) || "unknown";
+}
+
+function hasArg(ns, ...names) {
+  return names.some(n => ns.args.includes(n));
+}
+
+function getFlagNumber(ns, names, fallback = 0) {
+  for (const name of [].concat(names)) {
+    const idx = ns.args.indexOf(name);
+    if (idx >= 0) { const v = Number(ns.args[idx + 1]); if (Number.isFinite(v) && v >= 0) return v; }
+  }
+  return fallback;
+}
+
+export function autocomplete() {
+  return ["--scrape", "--copy-home", "--tail", "--rd-timeout", "--keep-rd"];
+}

--- a/darkweb/dnet-crawl.js
+++ b/darkweb/dnet-crawl.js
@@ -1,0 +1,573 @@
+// /darkweb/dnet-crawl.js — darknet resident agent
+// Spreads across the darknet, cracks servers (simple models inline, hard via
+// dnet-crack.js), records topology, maintains cache/RAM via dnet-ops.js.
+// ALL ns.dnet.* calls routed through rd() temp scripts.
+// In-game RAM: ~3-4 GB.
+//
+// Usage:
+//   run /darkweb/dnet-crawl.js [--tail] [--loop 30000] [--maint-ms 120000]
+//   run /darkweb/dnet-crawl.js --no-maint --no-spread --tail
+
+/** @param {NS} ns */
+export async function main(ns) {
+  ns.disableLog("ALL");
+
+  const HOST = ns.getHostname();
+  const HOME = "home";
+  const SELF = ns.getScriptName();
+  const DIR = dirname(SELF);
+  const path = name => DIR ? `${DIR}/${name}` : name;
+
+  const LEDGER   = "/darkweb/dnet-passwords.txt";
+  const MAP_FILE = "/darkweb/dnet-map.txt";
+  const OPS      = path("dnet-ops.js");
+  const CRACK    = path("dnet-crack.js");
+
+  const KILL_PORT   = getFlagNumber(ns, ["--kill-port"], 20);
+  const CMD_PORT    = getFlagNumber(ns, ["--cmd-port"],  21);
+  const KILL_PREFIX = "DNET_KILL|";
+  const CMD_PREFIX  = "DNET_CMD|";
+
+  const LOOP_MS       = getFlagNumber(ns, ["--loop"],     30_000);
+  const MAINT_MS      = getFlagNumber(ns, ["--maint-ms"], 120_000);
+  const RD_TIMEOUT_MS = getFlagNumber(ns, ["--rd-timeout"], 8_000);
+  const MAX_SPREAD    = getFlagNumber(ns, ["--max-spread"], 200);
+  const KEEP_RD       = hasArg(ns, "--keep-rd");
+  const NO_MAINT      = hasArg(ns, "--no-maint");
+  const NO_SPREAD     = hasArg(ns, "--no-spread");
+  const NO_SIMPLE     = hasArg(ns, "--no-simple");
+  const COPY_HOME     = hasArg(ns, "--copy-home") || HOST !== HOME;
+  const DOCTOR        = hasArg(ns, "--doctor");
+
+  if (hasArg(ns, "--tail")) {
+    try { ns.ui.openTail(); } catch (_) {}
+  }
+
+  if (DOCTOR) {
+    doctorCheck();
+    return;
+  }
+
+  ns.print(`[DNET-CRAWL] Started on ${HOST} loop=${LOOP_MS}ms maint=${MAINT_MS}ms`);
+
+  let lastMaint = 0;
+  let spreadCount = 0;
+  const crackedThisSession = new Set();
+  const failedThisSession  = new Set();
+  const sentToCracker      = new Set();
+
+  // Initial maintenance before main loop
+  if (!NO_MAINT) {
+    try {
+      const pid = ns.exec(OPS, HOST, { preventDuplicates: true }, "--realloc", "--open-caches");
+      if (pid) ns.print(`[DNET-CRAWL] Launched ${OPS} --realloc --open-caches pid=${pid}`);
+    } catch (_) {}
+    lastMaint = Date.now();
+  }
+
+  // Main loop
+  while (true) {
+    if (shouldDie()) {
+      ns.print(`[DNET-CRAWL] Kill signal received on port ${KILL_PORT}. Exiting.`);
+      return;
+    }
+
+    await handleCommandBus();
+
+    // Probe neighbors
+    const neighbors = await rd("probe", `ns.dnet.probe()`, []) ?? [];
+    if (neighbors.length === 0) {
+      ns.print(`[DNET-CRAWL] No neighbors found; sleeping ${LOOP_MS}ms`);
+      await ns.sleep(LOOP_MS);
+      continue;
+    }
+
+    // Batch-fetch server details
+    const detailsMap = await batchDetails(neighbors);
+
+    // Process each neighbor
+    for (const target of neighbors) {
+      if (shouldDie()) break;
+      if (crackedThisSession.has(target)) continue;
+
+      const det = detailsMap[target];
+      if (!det) continue;
+
+      // Already have a session — just spread if not yet done
+      if (det.hasSession) {
+        crackedThisSession.add(target);
+        if (!NO_SPREAD) await spreadTo(target);
+        continue;
+      }
+
+      // Check ledger first — reconnect if we know the password
+      const ledger = readLedger();
+      const rec = ledger.get(target);
+      if (rec?.password !== undefined) {
+        const ok = await rdConnect(target, rec.password);
+        if (ok?.success || ok?.session) {
+          ns.print(`[DNET-CRAWL] Reconnected ${target} via ledger`);
+          crackedThisSession.add(target);
+          if (!NO_SPREAD) await spreadTo(target);
+          continue;
+        }
+      }
+
+      if (failedThisSession.has(target)) continue;
+
+      const model = det.modelId ?? det.model ?? "?";
+      const pw = NO_SIMPLE ? null : await tryCrackSimple(target, det, model);
+
+      if (pw !== null && pw !== undefined) {
+        const session = await rdConnect(target, pw);
+        if (session?.success || session?.session) {
+          ns.print(`[DNET-CRAWL] [CRACKED] ${target} model=${model} pw="${pw}"`);
+          crackedThisSession.add(target);
+          await recordPassword(target, pw, model);
+          if (!NO_SPREAD) await spreadTo(target);
+          continue;
+        }
+      }
+
+      // Delegate to dnet-crack.js for hard models
+      if (!sentToCracker.has(target)) {
+        const modelId = det.modelId ?? "";
+        if (!isSimpleModel(modelId)) {
+          await sendToCracker(target);
+          sentToCracker.add(target);
+        }
+      }
+    }
+
+    // Record topology
+    updateMap(neighbors, detailsMap);
+    if (COPY_HOME && HOST !== HOME) {
+      try { await ns.scp(MAP_FILE, HOME, HOST); } catch (_) {}
+    }
+
+    // Periodic maintenance
+    if (!NO_MAINT && Date.now() - lastMaint >= MAINT_MS) {
+      try {
+        const pid = ns.exec(OPS, HOST, { preventDuplicates: true }, "--realloc", "--open-caches");
+        if (pid) ns.print(`[DNET-CRAWL] Maintenance ${OPS} pid=${pid}`);
+      } catch (_) {}
+      lastMaint = Date.now();
+    }
+
+    await ns.sleep(LOOP_MS);
+  }
+
+  // ── rd() RAM-dodge engine ───────────────────────────────────────────────────
+
+  async function rd(label, expr, args = [], timeoutMs = RD_TIMEOUT_MS) {
+    const token = `${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+    const safeLabel = String(label || "rd").replace(/[^a-zA-Z0-9_-]/g, "_");
+    const tempDir = DIR ? `${DIR}/Temp` : "/Temp";
+    const sf = `${tempDir}/dnet-rd-${safeLabel}-${token}.js`;
+    const of = `${tempDir}/dnet-rd-${safeLabel}-${token}.txt`;
+
+    const src = `/** @param {NS} ns */
+export async function main(ns) {
+  const outFile = ns.args[0];
+  const args = ns.args.slice(1).map(a => { try { return JSON.parse(a); } catch (_) { return a; } });
+  try {
+    const result = await (async () => (${expr}))();
+    await ns.write(outFile, JSON.stringify({ ok: true, result }), "w");
+  } catch (e) {
+    await ns.write(outFile, JSON.stringify({ ok: false, error: String(e) }), "w");
+  }
+}`;
+
+    try { await ns.write(sf, src, "w"); await ns.write(of, "", "w"); }
+    catch (e) { ns.print(`[RD] write failed ${safeLabel}: ${e}`); return null; }
+
+    const pid = ns.exec(sf, HOST, 1, of, ...args.map(a => JSON.stringify(a)));
+    if (!pid) {
+      ns.print(`[RD] exec failed ${sf}`);
+      if (!KEEP_RD) { try { ns.rm(sf, HOST); } catch (_) {} }
+      return null;
+    }
+
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline && ns.isRunning(pid)) await ns.sleep(50);
+    if (ns.isRunning(pid)) {
+      try { ns.kill(pid); } catch (_) {}
+      if (!KEEP_RD) { try { ns.rm(sf, HOST); } catch (_) {} try { ns.rm(of, HOST); } catch (_) {} }
+      return null;
+    }
+
+    let raw = "";
+    try { raw = ns.read(of); } catch (_) {}
+    if (!KEEP_RD) { try { ns.rm(sf, HOST); } catch (_) {} try { ns.rm(of, HOST); } catch (_) {} }
+
+    if (!raw) return null;
+    try {
+      const p = JSON.parse(raw);
+      if (!p.ok) { ns.print(`[RD] error ${safeLabel}: ${p.error}`); return null; }
+      return p.result;
+    } catch (e) { ns.print(`[RD] parse error ${safeLabel}: ${raw.slice(0, 100)}`); return null; }
+  }
+
+  // ── dnet API helpers ────────────────────────────────────────────────────────
+
+  async function batchDetails(hosts) {
+    if (!hosts.length) return {};
+    const expr = `(async()=>{
+      const out={};
+      for(const h of args){
+        try{ out[h]=await ns.dnet.getServerDetails(h); }catch(_){ out[h]=null; }
+      }
+      return out;
+    })()`;
+    const result = await rd("details", expr, hosts, RD_TIMEOUT_MS * hosts.length);
+    return result ?? {};
+  }
+
+  async function rdAuth(target, pw) {
+    return rd("auth", `ns.dnet.authenticate(args[0],args[1])`, [target, pw]);
+  }
+
+  async function rdConnect(target, pw) {
+    return rd("session", `ns.dnet.connectToSession(args[0],args[1])`, [target, pw]);
+  }
+
+  async function rdStorm(target) {
+    return rd("storm", `ns.dnet.unleashStormSeed()`, []);
+  }
+
+  async function rdStasis(link) {
+    return rd("stasis", `ns.dnet.setStasisLink(args[0])`, [link], 45_000);
+  }
+
+  async function rdBackdoor(target) {
+    return rd("backdoor", `ns.dnet.backdoor(args[0])`, [target], 30_000);
+  }
+
+  // ── Simple inline crackers ──────────────────────────────────────────────────
+
+  const DEFAULTS         = ["admin","password","0000","12345"];
+  const DOGS             = ["fido","spot","rover","max"];
+  const EU_COUNTRIES     = [
+    "Austria","Belgium","Bulgaria","Croatia","Republic of Cyprus","Czech Republic",
+    "Denmark","Estonia","Finland","France","Germany","Greece","Hungary","Ireland",
+    "Italy","Latvia","Lithuania","Luxembourg","Malta","Netherlands","Poland",
+    "Portugal","Romania","Slovakia","Slovenia","Spain","Sweden",
+  ];
+  const COMMON_PASSWORDS = [
+    "123456","password","123456789","12345678","12345","1234567","1234567890",
+    "qwerty","abc123","111111","123123","admin","letmein","welcome","monkey",
+    "dragon","master","shadow","qwerty123","1q2w3e4r","sunshine","princess",
+    "solo","1234","iloveyou","654321","superman","batman","trustno1","hello",
+    "freedom","michael","jessica","jesus","password1","ninja","mustang",
+    "access","test","baseball","soccer","hockey","dallas","yankees","robert",
+    "thomas","jordan","harley","ranger","daniel","andrew","andrea","joshua",
+    "george","hunter","buster","cookie","charlie","samantha","jessica","fuckyou",
+    "pepper","cheese","butter","summer","winter","spring","football","baseball",
+    "ginger","bailey","flower","rabbit","soccer","hockey","golfer","player",
+    "pass","asdf","zxcvbn","qwertyuiop","azerty","qweasdzxc","1qaz2wsx",
+    "abcdef","aaaaaa","000000","696969","123321","222222","999999","888888",
+    "7777777","1111111",
+  ];
+
+  function isSimpleModel(modelId) {
+    return [
+      "ZeroLogon","NoPassword",
+      "DeskMemo_3.1","EchoVuln",
+      "FreshInstall_1.0","DefaultPassword",
+      "CloudBlare(tm)","Captcha",
+      "Laika4","DogNames",
+      "BellaCuore","RomanNumeral",
+      "Pr0verFl0","BufferOverflow",
+    ].includes(modelId);
+  }
+
+  async function tryCrackSimple(target, det, model) {
+    switch (model) {
+      case "ZeroLogon": case "NoPassword":
+        return await tryPw(target, "");
+
+      case "DeskMemo_3.1": case "EchoVuln":
+        return await crackEcho(target, det);
+
+      case "FreshInstall_1.0": case "DefaultPassword":
+        return await tryCandidates(target, DEFAULTS);
+
+      case "CloudBlare(tm)": case "Captcha":
+        return await crackCaptcha(target, det);
+
+      case "Laika4": case "DogNames":
+        return await tryCandidates(target, DOGS);
+
+      case "BellaCuore": case "RomanNumeral":
+        if ((det.difficulty ?? 99) < 8) return await crackRomanSimple(target, det);
+        return null; // complex range case → delegate to dnet-crack.js
+
+      case "Pr0verFl0": case "BufferOverflow":
+        return await crackBufferOverflow(target, det);
+
+      default:
+        return null;
+    }
+  }
+
+  async function tryPw(target, pw) {
+    const r = await rdAuth(target, pw);
+    if (r?.success) return pw;
+    return null;
+  }
+
+  async function tryCandidates(target, list) {
+    for (const pw of list) {
+      const r = await rdAuth(target, pw);
+      if (r?.success) return pw;
+    }
+    return null;
+  }
+
+  async function crackEcho(target, det) {
+    const raw = String(det.data ?? det.passwordHint ?? "");
+    const nums = raw.replace(/[^0-9]/g, "");
+    if (!nums) return null;
+    return await tryPw(target, nums);
+  }
+
+  async function crackCaptcha(target, det) {
+    const raw = String(det.data ?? det.passwordHint ?? "");
+    const digits = raw.replace(/[^0-9]/g, "");
+    if (!digits) return null;
+    return await tryPw(target, digits);
+  }
+
+  async function crackRomanSimple(target, det) {
+    // diff < 8: single Roman numeral → parse to int
+    const raw = String(det.data ?? det.passwordHint ?? "");
+    const romanMatch = raw.match(/([IVXLCDM]+)/i);
+    if (!romanMatch) return null;
+    const n = parseRoman(romanMatch[1].toUpperCase());
+    if (!n) return null;
+    return await tryPw(target, String(n));
+  }
+
+  async function crackBufferOverflow(target, det) {
+    const passLen = det.passwordLength ?? 4;
+    const exploit = "A".repeat(passLen * 2);
+    return await tryPw(target, exploit);
+  }
+
+  function parseRoman(s) {
+    const vals = { I:1, V:5, X:10, L:50, C:100, D:500, M:1000 };
+    let total = 0, prev = 0;
+    for (let i = s.length - 1; i >= 0; i--) {
+      const v = vals[s[i]] ?? 0;
+      total += v < prev ? -v : v;
+      prev = v;
+    }
+    return total;
+  }
+
+  // ── Command bus ─────────────────────────────────────────────────────────────
+
+  async function handleCommandBus() {
+    const raw = ns.peek(CMD_PORT);
+    if (typeof raw !== "string" || !raw.startsWith(CMD_PREFIX)) return;
+
+    const rest = raw.slice(CMD_PREFIX.length);
+    const [id, expiresAtStr, action, encodedTarget = ""] = rest.split("|");
+    const expiresAt = Number(expiresAtStr ?? 0);
+    if (Date.now() > expiresAt) return;
+
+    const target = decodeURIComponent(encodedTarget);
+
+    ns.print(`[DNET-CRAWL] CMD id=${id} action=${action} target="${target}"`);
+
+    switch (action) {
+      case "stormseed": {
+        if (!ns.fileExists("STORM_SEED.exe", HOST)) break;
+        const r = await rdStorm();
+        ns.tprint(`[DNET-CRAWL] STORM_SEED unleashed: ${JSON.stringify(r)}`);
+        break;
+      }
+      case "stasis": {
+        if (!target || target === HOST) {
+          const r = await rdStasis(true);
+          ns.print(`[DNET-CRAWL] stasis(true): ${JSON.stringify(r)}`);
+        }
+        break;
+      }
+      case "unstasis": {
+        if (!target || target === HOST) {
+          const r = await rdStasis(false);
+          ns.print(`[DNET-CRAWL] stasis(false): ${JSON.stringify(r)}`);
+        }
+        break;
+      }
+      case "backdoor": {
+        if (!target || target === HOST) break;
+        const r = await rdBackdoor(target);
+        ns.print(`[DNET-CRAWL] backdoor(${target}): ${JSON.stringify(r)}`);
+        break;
+      }
+      case "backdoor-all": {
+        const neighbors = await rd("probe", `ns.dnet.probe()`, []) ?? [];
+        for (const h of neighbors) {
+          const r = await rdBackdoor(h);
+          ns.print(`[DNET-CRAWL] backdoor(${h}): ${JSON.stringify(r)}`);
+        }
+        break;
+      }
+    }
+  }
+
+  // ── Spreading ───────────────────────────────────────────────────────────────
+
+  async function spreadTo(target) {
+    if (NO_SPREAD || spreadCount >= MAX_SPREAD) return;
+    if (target === HOST || target === HOME) return;
+
+    // Files to copy
+    const files = [
+      SELF,
+      path("dnet-crack.js"),
+      path("dnet-ops.js"),
+      path("dnet-lab.js"),
+      path("dnet-ctl.js"),
+      LEDGER,
+    ].filter(f => {
+      try { return ns.fileExists(f, HOST); } catch (_) { return false; }
+    });
+
+    try {
+      await ns.scp(files, target, HOST);
+    } catch (e) {
+      ns.print(`[DNET-CRAWL] scp to ${target} failed: ${e}`);
+    }
+
+    try {
+      const pid = ns.exec(SELF, target, { preventDuplicates: true },
+        "--loop", LOOP_MS, "--maint-ms", MAINT_MS, "--rd-timeout", RD_TIMEOUT_MS);
+      if (pid) {
+        ns.print(`[DNET-CRAWL] Spread to ${target} pid=${pid}`);
+        spreadCount++;
+      }
+    } catch (e) {
+      ns.print(`[DNET-CRAWL] exec on ${target} failed: ${e}`);
+    }
+  }
+
+  // ── dnet-crack.js delegation ────────────────────────────────────────────────
+
+  async function sendToCracker(target) {
+    try {
+      const pid = ns.exec(CRACK, HOST, { preventDuplicates: true }, target);
+      if (pid) ns.print(`[DNET-CRAWL] Cracker → ${target} pid=${pid}`);
+    } catch (e) {
+      ns.print(`[DNET-CRAWL] exec crack failed for ${target}: ${e}`);
+    }
+  }
+
+  // ── Topology map ────────────────────────────────────────────────────────────
+
+  function updateMap(neighbors, detailsMap) {
+    try {
+      const existing = new Map();
+      try {
+        const raw = String(ns.read(MAP_FILE) || "");
+        for (const line of raw.split(/\r?\n/)) {
+          if (!line.trim()) continue;
+          const [h] = line.split("|");
+          if (h) existing.set(h, line);
+        }
+      } catch (_) {}
+
+      const ts = Date.now();
+      for (const h of neighbors) {
+        const det = detailsMap[h];
+        const ip = det?.ip ?? "";
+        const neighborList = neighbors.filter(n => n !== h).join(",");
+        existing.set(h, `${encodeURIComponent(h)}|${encodeURIComponent(ip)}|${ts}|${encodeURIComponent(neighborList)}`);
+      }
+
+      const rows = [...existing.values()].sort();
+      ns.write(MAP_FILE, rows.join("\n") + "\n", "w");
+    } catch (e) {
+      ns.print(`[DNET-CRAWL] map update error: ${e}`);
+    }
+  }
+
+  // ── Ledger ───────────────────────────────────────────────────────────────────
+
+  function readLedger() {
+    const out = new Map();
+    try {
+      const raw = String(ns.read(LEDGER) || "");
+      for (const line of raw.split(/\r?\n/)) {
+        if (!line.trim()) continue;
+        const [host, password = "", model = "?"] = line.split("|");
+        if (host) out.set(host, { password, model });
+      }
+    } catch (_) {}
+    return out;
+  }
+
+  async function recordPassword(host, password, model) {
+    const map = readLedger();
+    map.set(host, { password: String(password ?? ""), model: String(model ?? "?") });
+    const rows = [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([h, r]) => `${h}|${r.password}|${r.model}`);
+    try {
+      await ns.write(LEDGER, rows.join("\n") + "\n", "w");
+      if (COPY_HOME && HOST !== HOME) await ns.scp(LEDGER, HOME, HOST);
+    } catch (_) {}
+  }
+
+  // ── Kill signal ──────────────────────────────────────────────────────────────
+
+  function shouldDie() {
+    try {
+      const v = ns.peek(KILL_PORT);
+      return typeof v === "string" && v.startsWith(KILL_PREFIX);
+    } catch (_) { return false; }
+  }
+
+  // ── Doctor ───────────────────────────────────────────────────────────────────
+
+  function doctorCheck() {
+    const needed = [CRACK, OPS, path("dnet-lab.js"), path("dnet-ctl.js")];
+    for (const f of needed) {
+      const ok = ns.fileExists(f, HOST);
+      ns.tprint(`[DNET-CRAWL] ${ok ? "✓" : "✗"} ${f}`);
+    }
+    ns.tprint(`[DNET-CRAWL] Running on: ${HOST}`);
+    ns.tprint(`[DNET-CRAWL] Ledger: ${ns.fileExists(LEDGER, HOST) ? "present" : "missing"}`);
+  }
+}
+
+// ── Module helpers ────────────────────────────────────────────────────────────
+
+function dirname(file) {
+  const idx = String(file).lastIndexOf("/");
+  return idx <= 0 ? "" : file.slice(0, idx);
+}
+
+function hasArg(ns, ...names) {
+  return names.some(n => ns.args.includes(n));
+}
+
+function getFlagNumber(ns, names, fallback = 0) {
+  for (const name of names) {
+    const idx = ns.args.indexOf(name);
+    if (idx >= 0) {
+      const v = Number(ns.args[idx + 1]);
+      if (Number.isFinite(v) && v >= 0) return v;
+    }
+  }
+  return fallback;
+}
+
+export function autocomplete() {
+  return [
+    "--tail", "--loop", "--maint-ms", "--rd-timeout", "--max-spread",
+    "--no-maint", "--no-spread", "--no-simple", "--copy-home",
+    "--kill-port", "--cmd-port", "--keep-rd", "--doctor",
+  ];
+}

--- a/darkweb/dnet-ctl.js
+++ b/darkweb/dnet-ctl.js
@@ -1,0 +1,171 @@
+// /darkweb/dnet-ctl.js — darknet control plane
+// Combines dnet-kill.js + dnet-port.js with status command added.
+// No ns.dnet.* calls; RAM budget: ~1 GB.
+//
+// Usage:
+//   run /darkweb/dnet-ctl.js --kill [--restart]
+//   run /darkweb/dnet-ctl.js --stormseed [target]
+//   run /darkweb/dnet-ctl.js --stasis <target> | --unstasis <target>
+//   run /darkweb/dnet-ctl.js --backdoor <target> | --backdoor-all
+//   run /darkweb/dnet-ctl.js --status
+//   run /darkweb/dnet-ctl.js --clear | --clear-kill
+
+/** @param {NS} ns */
+export async function main(ns) {
+  ns.disableLog("ALL");
+
+  const SELF = ns.getScriptName();
+  const DIR = dirname(SELF);
+  const CRAWL = DIR ? `${DIR}/dnet-crawl.js` : "dnet-crawl.js";
+
+  const KILL_PORT = getFlagNumber(ns, ["--kill-port"], 20);
+  const CMD_PORT = getFlagNumber(ns, ["--cmd-port"], 21);
+  const KILL_PREFIX = "DNET_KILL|";
+  const CMD_PREFIX = "DNET_CMD|";
+  const TTL_MS = getFlagNumber(ns, ["--ttl-ms", "--ttl"], 15_000);
+
+  // ── --status ─────────────────────────────────────────────────────────────
+  if (hasArg(ns, "--status")) {
+    const killVal = ns.peek(KILL_PORT);
+    const cmdVal = ns.peek(CMD_PORT);
+    ns.tprint(`[DNET-CTL] Kill port ${KILL_PORT}: ${JSON.stringify(killVal)}`);
+    ns.tprint(`[DNET-CTL] Cmd  port ${CMD_PORT}: ${JSON.stringify(cmdVal)}`);
+    return;
+  }
+
+  // ── --clear-kill ──────────────────────────────────────────────────────────
+  if (hasArg(ns, "--clear-kill")) {
+    clearPort(ns, KILL_PORT);
+    ns.tprint(`[DNET-CTL] Cleared kill port ${KILL_PORT}.`);
+    return;
+  }
+
+  // ── --clear ───────────────────────────────────────────────────────────────
+  if (hasArg(ns, "--clear")) {
+    clearPort(ns, CMD_PORT);
+    ns.tprint(`[DNET-CTL] Cleared command port ${CMD_PORT}.`);
+    return;
+  }
+
+  // ── --kill ────────────────────────────────────────────────────────────────
+  if (hasArg(ns, "--kill")) {
+    const signal = `${KILL_PREFIX}${Date.now()}`;
+    clearPort(ns, KILL_PORT);
+    await ns.writePort(KILL_PORT, signal);
+    ns.tprint(`[DNET-CTL] Kill signal sent on port ${KILL_PORT}: ${signal}`);
+
+    if (hasArg(ns, "--restart")) {
+      await ns.sleep(5_000);
+      clearPort(ns, KILL_PORT);
+      const args = ["--tail"];
+      const pid = ns.run(CRAWL, 1, ...args);
+      ns.tprint(pid > 0
+        ? `[DNET-CTL] Restarted ${CRAWL} pid=${pid}`
+        : `[DNET-CTL] Restart failed — run ${CRAWL} manually`);
+    }
+    return;
+  }
+
+  // ── command bus ───────────────────────────────────────────────────────────
+  const parsed = parseActionAndTarget(ns);
+  if (!parsed.action) {
+    ns.tprint([
+      "Usage:",
+      `  run ${SELF} --kill [--restart]`,
+      `  run ${SELF} --stormseed [target]`,
+      `  run ${SELF} --stasis <target>`,
+      `  run ${SELF} --unstasis <target>`,
+      `  run ${SELF} --backdoor <target>`,
+      `  run ${SELF} --backdoor-all`,
+      `  run ${SELF} --status`,
+      `  run ${SELF} --clear`,
+      `  run ${SELF} --clear-kill`,
+    ].join("\n"));
+    return;
+  }
+
+  if ((parsed.action === "backdoor" || parsed.action === "stasis" || parsed.action === "unstasis") && !parsed.target) {
+    ns.tprint(`[DNET-CTL] ${parsed.action} requires a <target> hostname or IP.`);
+    return;
+  }
+
+  const id = `${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+  const expiresAt = Date.now() + Math.max(1_000, TTL_MS);
+  const signal = `${CMD_PREFIX}${id}|${expiresAt}|${parsed.action}|${encodeURIComponent(parsed.target || "")}`;
+
+  clearPort(ns, CMD_PORT);
+  await ns.writePort(CMD_PORT, signal);
+  ns.tprint(`[DNET-CTL] ${parsed.action} → port ${CMD_PORT}; target="${parsed.target || "*"}"; ttl=${TTL_MS}ms; id=${id}`);
+
+  if (!hasArg(ns, "--no-reset")) {
+    await ns.sleep(Math.max(1_000, TTL_MS));
+    if (ns.peek(CMD_PORT) === signal) {
+      clearPort(ns, CMD_PORT);
+      ns.tprint(`[DNET-CTL] Command port ${CMD_PORT} auto-cleared.`);
+    }
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function parseActionAndTarget(ns) {
+  const defs = [
+    ["stormseed",    ["--stormseed", "--storm"]],
+    ["backdoor-all", ["--backdoor-all"]],
+    ["backdoor",     ["--backdoor"]],
+    ["stasis",       ["--stasis"]],
+    ["unstasis",     ["--unstasis", "--remove-stasis"]],
+  ];
+  for (const [action, flags] of defs) {
+    for (const flag of flags) {
+      const idx = ns.args.indexOf(flag);
+      if (idx < 0) continue;
+      const next = ns.args[idx + 1];
+      const explicit = getFlagValue(ns, ["--target"]);
+      const target = explicit || (next !== undefined && !String(next).startsWith("-") ? String(next) : "");
+      return { action, target };
+    }
+  }
+  return { action: "", target: "" };
+}
+
+function clearPort(ns, port) {
+  try { ns.clearPort(port); }
+  catch (_) { try { ns.getPortHandle(port).clear(); } catch (_) {} }
+}
+
+function dirname(file) {
+  const idx = String(file).lastIndexOf("/");
+  return idx <= 0 ? "" : file.slice(0, idx);
+}
+
+function hasArg(ns, ...names) {
+  return names.some(n => ns.args.includes(n));
+}
+
+function getFlagNumber(ns, names, fallback = 0) {
+  for (const name of names) {
+    const idx = ns.args.indexOf(name);
+    if (idx >= 0) {
+      const v = Number(ns.args[idx + 1]);
+      if (Number.isFinite(v) && v >= 0) return v;
+    }
+  }
+  return fallback;
+}
+
+function getFlagValue(ns, names) {
+  for (const name of names) {
+    const idx = ns.args.indexOf(name);
+    if (idx >= 0 && ns.args[idx + 1] !== undefined) return String(ns.args[idx + 1]);
+  }
+  return "";
+}
+
+export function autocomplete() {
+  return [
+    "--kill", "--restart", "--stormseed", "--stasis", "--unstasis",
+    "--backdoor", "--backdoor-all", "--status", "--clear", "--clear-kill",
+    "--target", "--ttl-ms", "--kill-port", "--cmd-port", "--no-reset",
+  ];
+}

--- a/darkweb/dnet-lab.js
+++ b/darkweb/dnet-lab.js
@@ -1,0 +1,269 @@
+// /darkweb/dnet-lab.js — RAM-dodged labyrinth solver
+// Solves any of the 7 Labyrinth variants via DFS. All ns.dnet.* calls are
+// embedded inside a SINGLE rd() temp script (critical: labyrinth state is
+// tied to the PID, so all movement must happen in one continuous execution).
+// In-game RAM: ~2 GB. Temp script runs for up to 10 minutes for large mazes.
+//
+// Usage:
+//   run /darkweb/dnet-lab.js [hostname]   -- auto-detects if omitted
+//   run /darkweb/dnet-lab.js NormalLab --tail
+
+/** @param {NS} ns */
+export async function main(ns) {
+  ns.disableLog("ALL");
+
+  const HOST = ns.getHostname();
+  const SELF = ns.getScriptName();
+  const DIR = dirname(SELF);
+  const path = name => DIR ? `${DIR}/${name}` : name;
+
+  const LEDGER = "/darkweb/dnet-passwords.txt";
+  const OPS = path("dnet-ops.js");
+
+  const RD_TIMEOUT_MS = 600_000; // 10-minute timeout for full maze traversal
+  const KEEP_RD = hasArg(ns, "--keep-rd");
+  const NO_RADAR = hasArg(ns, "--no-radar");
+  const KILL_PORT = 20;
+  const KILL_PREFIX = "DNET_KILL|";
+
+  if (hasArg(ns, "--tail")) {
+    try { ns.ui.openTail(); } catch (_) {}
+  }
+
+  // Detect labyrinth host from args or probe neighbors
+  let labHost = String(ns.args[0] ?? "");
+  if (!labHost || labHost.startsWith("-")) {
+    labHost = await detectLabHost();
+    if (!labHost) {
+      ns.tprint("[DNET-LAB] No labyrinth server found in neighbors. Specify hostname as first arg.");
+      return;
+    }
+  }
+
+  ns.print(`[DNET-LAB] Solving labyrinth: ${labHost}`);
+
+  // The entire DFS solver runs as a single rd() temp script so the PID
+  // (which tracks labyrinth position) stays consistent throughout navigation.
+  const expr = buildLabSolverExpr();
+  const result = await rd("lab-dfs", expr, [labHost, NO_RADAR], RD_TIMEOUT_MS);
+
+  if (!result?.success) {
+    ns.tprint(`[DNET-LAB] Labyrinth failed for ${labHost}: ${JSON.stringify(result)}`);
+    return;
+  }
+
+  const pw = String(result.password ?? "");
+  ns.tprint(`[DNET-LAB] Labyrinth SOLVED! ${labHost} password="${pw}" in ${result.steps} steps`);
+
+  await recordPassword(labHost, pw, "(The Labyrinth)");
+
+  // Open the cache reward from the lab
+  try {
+    const pid = ns.exec(OPS, HOST, { preventDuplicates: true }, "--open-caches");
+    if (pid) ns.print(`[DNET-LAB] Launched ${OPS} --open-caches pid=${pid}`);
+  } catch (_) {}
+
+  // ── rd() RAM-dodge engine ─────────────────────────────────────────────────
+
+  async function rd(label, expr, args = [], timeoutMs = 8_000) {
+    const token = `${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+    const safeLabel = String(label || "rd").replace(/[^a-zA-Z0-9_-]/g, "_");
+    const tempDir = DIR ? `${DIR}/Temp` : "/Temp";
+    const sf = `${tempDir}/dnet-rd-${safeLabel}-${token}.js`;
+    const of = `${tempDir}/dnet-rd-${safeLabel}-${token}.txt`;
+
+    const src = `/** @param {NS} ns */
+export async function main(ns) {
+  const outFile = ns.args[0];
+  const args = ns.args.slice(1).map(a => { try { return JSON.parse(a); } catch (_) { return a; } });
+  try {
+    const result = await (async () => (${expr}))();
+    await ns.write(outFile, JSON.stringify({ ok: true, result }), "w");
+  } catch (e) {
+    await ns.write(outFile, JSON.stringify({ ok: false, error: String(e) }), "w");
+  }
+}`;
+
+    try { await ns.write(sf, src, "w"); await ns.write(of, "", "w"); }
+    catch (e) { ns.print(`[RD] write failed ${safeLabel}: ${e}`); return null; }
+
+    const pid = ns.exec(sf, HOST, 1, of, ...args.map(a => JSON.stringify(a)));
+    if (!pid) {
+      ns.print(`[RD] exec failed ${sf}`);
+      if (!KEEP_RD) { try { ns.rm(sf, HOST); } catch (_) {} }
+      return null;
+    }
+
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline && ns.isRunning(pid)) await ns.sleep(200);
+    if (ns.isRunning(pid)) {
+      try { ns.kill(pid); } catch (_) {}
+      if (!KEEP_RD) { try { ns.rm(sf, HOST); } catch (_) {} try { ns.rm(of, HOST); } catch (_) {} }
+      return null;
+    }
+
+    let raw = "";
+    try { raw = ns.read(of); } catch (_) {}
+    if (!KEEP_RD) { try { ns.rm(sf, HOST); } catch (_) {} try { ns.rm(of, HOST); } catch (_) {} }
+
+    if (!raw) return null;
+    try {
+      const p = JSON.parse(raw);
+      if (!p.ok) { ns.print(`[RD] error ${safeLabel}: ${p.error}`); return null; }
+      return p.result;
+    } catch (e) { ns.print(`[RD] parse error ${safeLabel}: ${raw.slice(0, 100)}`); return null; }
+  }
+
+  // Probe neighbors to find a lab server
+  async function detectLabHost() {
+    const neighbors = await rd("probe", `ns.dnet.probe()`, [], 8_000) ?? [];
+    const labNames = ["NormalLab","CruelLab","MercilessLab","UberLab","EternalLab","EndlessLab","FinalLab","BonusLab"];
+    for (const h of neighbors) {
+      if (labNames.some(n => h.toLowerCase().includes(n.toLowerCase()))) return h;
+    }
+    // Check details for labyrinth modelId
+    for (const h of neighbors) {
+      const d = await rd("details", `ns.dnet.getServerDetails(args[0])`, [h], 8_000);
+      if (d?.modelId === "(The Labyrinth)") return h;
+    }
+    return null;
+  }
+
+  // ── Ledger ────────────────────────────────────────────────────────────────
+
+  async function recordPassword(host, password, model) {
+    const map = new Map();
+    try {
+      const raw = String(ns.read(LEDGER) || "");
+      for (const line of raw.split(/\r?\n/)) {
+        if (!line.trim()) continue;
+        const [h, pw = "", m = "?"] = line.split("|");
+        if (h) map.set(h, { password: pw, model: m });
+      }
+    } catch (_) {}
+    map.set(host, { password: String(password ?? ""), model });
+    const rows = [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([h, r]) => `${h}|${r.password}|${r.model}`);
+    try { await ns.write(LEDGER, rows.join("\n") + "\n", "w"); } catch (_) {}
+    ns.print(`[DNET-LAB] Saved password for ${host} in ledger`);
+  }
+}
+
+// ── Labyrinth solver expression (runs inside the temp script) ─────────────────
+// IMPORTANT: This entire function runs as a single PID so labyrinth state is consistent.
+// The temp script calls ns.dnet.labreport() and ns.dnet.authenticate(host, dir).
+
+function buildLabSolverExpr() {
+  return String.raw`(async () => {
+  const host = args[0];
+  const noRadar = args[1] === true || args[1] === "true";
+
+  const rev = { north: "south", south: "north", east: "west", west: "east" };
+  const deltas = { north: [0, -2], south: [0, 2], east: [2, 0], west: [-2, 0] };
+  const DIRS = ["north", "east", "south", "west"];
+
+  // Get initial position via labreport (free call, no state change)
+  let loc;
+  try { loc = await ns.dnet.labreport(); } catch (e) {
+    return { success: false, error: String(e), step: "labreport" };
+  }
+  if (!loc?.coords) return { success: false, error: "no coords from labreport" };
+  if (loc.code === 451) return { success: false, error: "insufficient charisma" };
+
+  let [cx, cy] = loc.coords;
+  const visited = new Set([cx + "," + cy]);
+  let steps = 0;
+
+  const stack = [{ remaining: DIRS.filter(d => loc[d]), back: null }];
+  ns.print("[LAB-DFS] start [" + cx + "," + cy + "] open: " + DIRS.filter(d => loc[d]).join(","));
+
+  while (stack.length > 0) {
+    const frame = stack[stack.length - 1];
+
+    // Skip already-visited neighbors
+    while (frame.remaining.length > 0) {
+      const [ndx, ndy] = deltas[frame.remaining[0]];
+      if (visited.has((cx + ndx) + "," + (cy + ndy))) frame.remaining.shift();
+      else break;
+    }
+
+    if (frame.remaining.length === 0) {
+      // Backtrack
+      stack.pop();
+      if (frame.back) {
+        const [bdx, bdy] = deltas[frame.back];
+        await ns.dnet.authenticate(host, frame.back);
+        cx += bdx; cy += bdy;
+        steps++;
+        ns.print("[LAB-DFS] ← backtrack [" + cx + "," + cy + "] depth=" + stack.length);
+      }
+      continue;
+    }
+
+    const dir = frame.remaining.shift();
+    const r = await ns.dnet.authenticate(host, dir);
+    steps++;
+
+    // Exit reached
+    if (r?.success) {
+      const pw = String(r.data ?? "");
+      ns.print("[LAB-DFS] SOLVED! steps=" + steps + " cells=" + visited.size + " pw=" + pw);
+      return { success: true, password: pw, steps, cells: visited.size };
+    }
+
+    const msg = String(r?.message ?? "");
+
+    // Insufficient charisma mid-run
+    if (r?.code === 451) return { success: false, error: "charisma dropped mid-run", steps };
+
+    // Wall (should not happen with visited filter, but guard anyway)
+    if (!msg.includes("moved to")) {
+      ns.print("[LAB-DFS] wall " + dir + " at [" + cx + "," + cy + "]");
+      continue;
+    }
+
+    // Successful move
+    const [dx, dy] = deltas[dir];
+    cx += dx; cy += dy;
+    visited.add(cx + "," + cy);
+
+    // Parse open directions from 3x3 surroundings in r.data
+    const lines = String(r.data ?? "").split("\n");
+    const open = [];
+    if (lines.length >= 3) {
+      if (lines[0]?.[1] === " ") open.push("north");
+      if (lines[1]?.[2] === " ") open.push("east");
+      if (lines[2]?.[1] === " ") open.push("south");
+      if (lines[1]?.[0] === " ") open.push("west");
+    } else {
+      open.push(...DIRS); // fallback: try all, DFS handles walls
+    }
+
+    ns.print("[LAB-DFS] → " + dir + " [" + cx + "," + cy + "] open:" + open.join(",") + " depth=" + stack.length);
+    stack.push({ remaining: open, back: rev[dir] });
+
+    if (steps % 50 === 0) await ns.sleep(0);
+  }
+
+  return { success: false, error: "DFS exhausted all paths", steps, cells: visited.size };
+})()`;
+}
+
+// ── Module helpers ────────────────────────────────────────────────────────────
+
+function dirname(file) {
+  const idx = String(file).lastIndexOf("/");
+  return idx <= 0 ? "" : file.slice(0, idx);
+}
+
+function hasArg(ns, ...names) {
+  return names.some(n => ns.args.includes(n));
+}
+
+export function autocomplete() {
+  return [
+    "NormalLab", "CruelLab", "MercilessLab", "UberLab",
+    "EternalLab", "EndlessLab", "FinalLab", "BonusLab",
+    "--tail", "--no-radar", "--keep-rd",
+  ];
+}

--- a/darkweb/dnet-ops.js
+++ b/darkweb/dnet-ops.js
@@ -1,0 +1,269 @@
+// /darkweb/dnet-ops.js — darknet maintenance (caches, realloc, phish, storm, stasis)
+// All ns.dnet.* calls routed through rd() temp scripts.
+// In-game RAM: ~2-3 GB.
+//
+// Usage:
+//   run /darkweb/dnet-ops.js --open-caches
+//   run /darkweb/dnet-ops.js --realloc [N]
+//   run /darkweb/dnet-ops.js --phish
+//   run /darkweb/dnet-ops.js --stormseed
+//   run /darkweb/dnet-ops.js --stasis [true|false]
+
+/** @param {NS} ns */
+export async function main(ns) {
+  ns.disableLog("ALL");
+
+  const HOST = ns.getHostname();
+  const HOME = "home";
+  const SELF = ns.getScriptName();
+  const DIR = dirname(SELF);
+
+  const LEDGER = "/darkweb/dnet-passwords.txt";
+  const KILL_PORT = 20;
+  const KILL_PREFIX = "DNET_KILL|";
+
+  const RD_TIMEOUT_MS = getFlagNumber(ns, ["--rd-timeout"], 10_000);
+  const KEEP_RD = hasArg(ns, "--keep-rd");
+  const MAX_REALLOC = getFlagNumber(ns, ["--realloc"], 25);
+  const MAX_TARGETS = getFlagNumber(ns, ["--targets"], 50);
+  const DO_PHISH = hasArg(ns, "--phish");
+  const DO_CACHES = hasArg(ns, "--open-caches");
+  const DO_REALLOC = hasArg(ns, "--realloc") || (!hasArg(ns, "--open-caches") && !hasArg(ns, "--phish") && !hasArg(ns, "--stormseed") && !hasArg(ns, "--stasis"));
+  const DO_STORM = hasArg(ns, "--stormseed");
+  const DO_STASIS = hasArg(ns, "--stasis");
+  const STASIS_VALUE = (() => {
+    const idx = ns.args.indexOf("--stasis");
+    if (idx >= 0 && ns.args[idx + 1] !== undefined) {
+      const v = String(ns.args[idx + 1]);
+      if (v === "false" || v === "0") return false;
+    }
+    return true;
+  })();
+
+  if (hasArg(ns, "--tail")) {
+    try { ns.ui.openTail(); } catch (_) {}
+  }
+
+  if (shouldDie()) return;
+
+  if (HOST !== HOME) await pullLedgerFromHome();
+
+  if (DO_REALLOC) await freeNeighborBlockedRam();
+  if (DO_CACHES || DO_REALLOC) await openLocalCaches();
+  if (DO_PHISH && HOST !== HOME && HOST !== "darkweb") {
+    await doPhish();
+    await openLocalCaches();
+  }
+  if (DO_STORM && HOST !== HOME && HOST !== "darkweb") await doStormSeed();
+  if (DO_STASIS && HOST !== HOME && HOST !== "darkweb") await doStasis(STASIS_VALUE);
+
+  // ── rd() RAM-dodge engine ─────────────────────────────────────────────────
+
+  async function rd(label, expr, args = [], timeoutMs = RD_TIMEOUT_MS) {
+    const token = `${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+    const safeLabel = String(label || "rd").replace(/[^a-zA-Z0-9_-]/g, "_");
+    const tempDir = DIR ? `${DIR}/Temp` : "/Temp";
+    const sf = `${tempDir}/dnet-rd-${safeLabel}-${token}.js`;
+    const of = `${tempDir}/dnet-rd-${safeLabel}-${token}.txt`;
+
+    const src = `/** @param {NS} ns */
+export async function main(ns) {
+  const outFile = ns.args[0];
+  const args = ns.args.slice(1).map(a => { try { return JSON.parse(a); } catch (_) { return a; } });
+  try {
+    const result = await (async () => (${expr}))();
+    await ns.write(outFile, JSON.stringify({ ok: true, result }), "w");
+  } catch (e) {
+    await ns.write(outFile, JSON.stringify({ ok: false, error: String(e) }), "w");
+  }
+}`;
+
+    try { await ns.write(sf, src, "w"); await ns.write(of, "", "w"); }
+    catch (e) { ns.print(`[RD] write failed ${safeLabel}: ${e}`); return null; }
+
+    const pid = ns.exec(sf, HOST, 1, of, ...args.map(a => JSON.stringify(a)));
+    if (!pid) {
+      ns.print(`[RD] exec failed ${sf}`);
+      if (!KEEP_RD) { try { ns.rm(sf, HOST); } catch (_) {} }
+      return null;
+    }
+
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline && ns.isRunning(pid)) await ns.sleep(50);
+    if (ns.isRunning(pid)) {
+      try { ns.kill(pid); } catch (_) {}
+      if (!KEEP_RD) { try { ns.rm(sf, HOST); } catch (_) {} try { ns.rm(of, HOST); } catch (_) {} }
+      return null;
+    }
+
+    let raw = "";
+    try { raw = ns.read(of); } catch (_) {}
+    if (!KEEP_RD) { try { ns.rm(sf, HOST); } catch (_) {} try { ns.rm(of, HOST); } catch (_) {} }
+
+    if (!raw) return null;
+    try {
+      const p = JSON.parse(raw);
+      if (!p.ok) { ns.print(`[RD] error ${safeLabel}: ${p.error}`); return null; }
+      return p.result;
+    } catch (e) { ns.print(`[RD] parse error ${safeLabel}: ${raw.slice(0, 100)}`); return null; }
+  }
+
+  // ── dnet API wrappers ─────────────────────────────────────────────────────
+
+  async function rdProbe() {
+    return rd("probe", `ns.dnet.probe()`, []);
+  }
+
+  async function rdGetBlockedRam(target) {
+    const r = await rd("blockedram", `(()=>{try{return ns.dnet.getBlockedRam(args[0])}catch(_){try{return ns.dnet.getServerDetails(args[0]).blockedRam}catch(__){return 0}}})()`, [target]);
+    return Number.isFinite(r) ? r : 0;
+  }
+
+  async function rdMemRealloc(target) {
+    return rd("realloc", `ns.dnet.memoryReallocation(args[0])`, [target], RD_TIMEOUT_MS * 2);
+  }
+
+  async function rdOpenCache(file) {
+    return rd("cache", `ns.dnet.openCache(args[0])`, [file]);
+  }
+
+  async function rdPhish() {
+    return rd("phish", `ns.dnet.phishingAttack()`, [], RD_TIMEOUT_MS * 2);
+  }
+
+  async function rdStorm() {
+    return rd("storm", `ns.dnet.unleashStormSeed()`, []);
+  }
+
+  async function rdStasis(link) {
+    return rd("stasis", `ns.dnet.setStasisLink(args[0])`, [link], 45_000);
+  }
+
+  async function rdConnect(host, pw) {
+    return rd("session", `ns.dnet.connectToSession(args[0],args[1])`, [host, pw]);
+  }
+
+  // ── Operations ────────────────────────────────────────────────────────────
+
+  async function freeNeighborBlockedRam() {
+    const neighbors = await rdProbe() ?? [];
+    const ledger = readLedger();
+    let targets = 0;
+
+    for (const target of neighbors) {
+      if (shouldDie()) return;
+      if (target === "darkweb") continue;
+      if (++targets > MAX_TARGETS) break;
+
+      const rec = ledger.get(target);
+      if (rec) await rdConnect(target, rec.password);
+
+      let blocked = await rdGetBlockedRam(target);
+      if (!(blocked > 0)) continue;
+
+      ns.print(`[DNET-OPS] realloc ${target} blocked=${blocked.toFixed(2)}GB`);
+
+      for (let i = 0; i < MAX_REALLOC; i++) {
+        if (shouldDie()) return;
+        const result = await rdMemRealloc(target);
+        const done = result?.done === true;
+        const freed = result?.ram ?? result?.recoveredRam ?? result?.freedRam ?? "?";
+        ns.print(`[DNET-OPS] memoryReallocation(${target}) #${i + 1} done=${done} freed=${freed}`);
+        await openLocalCaches();
+        if (done) break;
+
+        blocked = await rdGetBlockedRam(target);
+        if (!(blocked > 0)) break;
+        await ns.sleep(200);
+      }
+    }
+  }
+
+  async function openLocalCaches() {
+    let caches = [];
+    try { caches = ns.ls(HOST, ".cache"); } catch (e) { ns.print(`[DNET-OPS] ls cache error: ${e}`); return; }
+
+    for (const file of caches) {
+      if (shouldDie()) return;
+      const result = await rdOpenCache(file);
+      ns.tprint(`[DNET-OPS] CACHE ${HOST}/${file}: ${JSON.stringify(result)}`);
+      try { ns.rm(file, HOST); } catch (_) {}
+    }
+  }
+
+  async function doPhish() {
+    const result = await rdPhish();
+    if (result) ns.print(`[DNET-OPS] phish money=${result.money ?? 0} exp=${result.exp ?? result.xp ?? 0}`);
+    else ns.print(`[DNET-OPS] phishingAttack returned null`);
+  }
+
+  async function doStormSeed() {
+    if (!ns.fileExists("STORM_SEED.exe", HOST)) {
+      ns.print(`[DNET-OPS] STORM_SEED.exe not on ${HOST}; skipping`);
+      return;
+    }
+    ns.tprint(`[DNET-OPS] Unleashing STORM_SEED on ${HOST}...`);
+    const result = await rdStorm();
+    ns.tprint(`[DNET-OPS] STORM_SEED result: ${JSON.stringify(result)}`);
+  }
+
+  async function doStasis(link) {
+    ns.tprint(`[DNET-OPS] setStasisLink(${link}) on ${HOST}...`);
+    const result = await rdStasis(link);
+    ns.tprint(`[DNET-OPS] stasis result: ${JSON.stringify(result)}`);
+  }
+
+  // ── Ledger helpers ────────────────────────────────────────────────────────
+
+  function readLedger() {
+    const out = new Map();
+    try {
+      const raw = String(ns.read(LEDGER) || "");
+      for (const line of raw.split(/\r?\n/)) {
+        if (!line.trim()) continue;
+        const [host, password = "", model = "?"] = line.split("|");
+        if (host) out.set(host, { password, model });
+      }
+    } catch (_) {}
+    return out;
+  }
+
+  async function pullLedgerFromHome() {
+    try { if (ns.fileExists(LEDGER, HOME)) await ns.scp(LEDGER, HOST, HOME); }
+    catch (e) { ns.print(`[DNET-OPS] ledger pull failed: ${e}`); }
+  }
+
+  function shouldDie() {
+    const v = ns.peek(KILL_PORT);
+    return typeof v === "string" && v.startsWith(KILL_PREFIX);
+  }
+}
+
+// ── Module helpers ────────────────────────────────────────────────────────────
+
+function dirname(file) {
+  const idx = String(file).lastIndexOf("/");
+  return idx <= 0 ? "" : file.slice(0, idx);
+}
+
+function hasArg(ns, ...names) {
+  return names.some(n => ns.args.includes(n));
+}
+
+function getFlagNumber(ns, names, fallback = 0) {
+  for (const name of names) {
+    const idx = ns.args.indexOf(name);
+    if (idx >= 0) {
+      const v = Number(ns.args[idx + 1]);
+      if (Number.isFinite(v) && v >= 0) return v;
+    }
+  }
+  return fallback;
+}
+
+export function autocomplete() {
+  return [
+    "--open-caches", "--realloc", "--phish", "--stormseed",
+    "--stasis", "--tail", "--rd-timeout", "--keep-rd", "--targets",
+  ];
+}


### PR DESCRIPTION
Replaces the 15.60 GB dnet-auth.js and associated scripts with a production-quality 5-file package where ALL ns.dnet.* API calls are routed through ephemeral temp scripts (rd() pattern), keeping each script under 4 GB in-game.

- dnet-crawl.js: Resident agent; spreads across darknet, cracks simple models inline (ZeroLogon, EchoVuln, FreshInstall, Captcha, DogNames, BellaCuore-simple, BufferOverflow), delegates hard models to dnet-crack.js, handles command bus and topology recording.

- dnet-crack.js: Heavy cracker for all 25 password models, source- confirmed strategies. Fixes: exact EU country list (Republic of Cyprus / Czech Republic / Netherlands), BigMo%od formula ((P%n)%((n-1)%32+1)=r), timing attack measured inside temp script to avoid exec-overhead variance.

- dnet-ops.js: Maintenance helper -- memoryReallocation, cache opening, phishingAttack, STORM_SEED, stasis links. All via rd().

- dnet-lab.js: Labyrinth DFS solver. Embeds entire maze traversal in a single rd() call (10-min timeout) so the temp script PID stays constant -- required because labyrinth position is tracked per PID.

- dnet-ctl.js: Control plane for kill signal (port 20) and command bus (port 21): --kill, --stormseed, --stasis, --unstasis, --backdoor, --backdoor-all, --status, --clear.
